### PR TITLE
feat: add API documentation exposure and Swagger integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -124,6 +124,11 @@ res.write(`data: ${JSON.stringify({ progress: 50, message: 'Processing...' })}\n
 res.flush();
 ```
 
+### API Documentation Sync (MANDATORY)
+- When creating or changing API JSON/OpenAPI-related outputs, also update the corresponding `@swagger` JSDoc annotations in source files (`server.js`, `routes/*.js`, `schemas.js`).
+- Keep `OPENAPI/openapi.json` synchronized with current JSDoc definitions after API changes.
+- Do not merge API endpoint/response changes if JSDoc and generated OpenAPI spec are out of sync.
+
 ## Testing & Debugging
 
 ### Key Test Files

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY --chown=node:node routes ./routes/
 COPY --chown=node:node services ./services/
 COPY --chown=node:node views ./views/
 COPY --chown=node:node public ./public/
+COPY --chown=node:node OPENAPI ./OPENAPI/
 COPY --chown=node:node schemas.js swagger.js ecosystem.config.js package.json ./
 
 # Make startup script executable

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -13,6 +13,7 @@ COPY --chown=node:node routes ./routes/
 COPY --chown=node:node services ./services/
 COPY --chown=node:node views ./views/
 COPY --chown=node:node public ./public/
+COPY --chown=node:node OPENAPI ./OPENAPI/
 COPY --chown=node:node schemas.js swagger.js ./
 COPY docker-entrypoint.sh ./
 

--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -509,6 +509,17 @@
               }
             }
           },
+          "302": {
+            "description": "Redirect to login when authentication is missing or invalid",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string",
+                  "example": "/login"
+                }
+              }
+            }
+          },
           "404": {
             "description": "OpenAPI specification file not found",
             "content": {
@@ -528,6 +539,62 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api-docs.json": {
+      "get": {
+        "summary": "Redirect to OpenAPI specification endpoint",
+        "description": "Backward-compatible redirect to `/api-docs/openapi.json`.",
+        "tags": [
+          "API",
+          "System"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirects to `/api-docs/openapi.json`"
+          }
+        }
+      }
+    },
+    "/rag": {
+      "get": {
+        "summary": "RAG chat interface page",
+        "description": "Renders the RAG interface for asking questions against indexed documents.",
+        "tags": [
+          "Navigation",
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "RAG page rendered successfully",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
           }
         }
       }
@@ -637,6 +704,317 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/rag/search": {
+      "post": {
+        "summary": "Search indexed documents",
+        "description": "Performs a hybrid RAG search across indexed documents using the provided query and optional filters.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "query"
+                ],
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "example": "invoice march 2026"
+                  },
+                  "from_date": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "to_date": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "correspondent": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required query"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/rag/ask": {
+      "post": {
+        "summary": "Ask a question against indexed documents",
+        "description": "Returns an AI-generated answer grounded in indexed document content.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "question"
+                ],
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "example": "Which invoices are overdue?"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer generated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required question"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/rag/index": {
+      "post": {
+        "summary": "Start document indexing",
+        "description": "Starts or re-runs indexing in the RAG backend.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indexing triggered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/rag/index/status": {
+      "get": {
+        "summary": "Get indexing status",
+        "description": "Returns current status information for RAG indexing.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indexing status returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/rag/index/check": {
+      "get": {
+        "summary": "Check whether re-indexing is required",
+        "description": "Compares source state and returns whether RAG index updates are needed.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Check completed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/rag/status": {
+      "get": {
+        "summary": "Get RAG backend status",
+        "description": "Returns status details for RAG service and AI backend connectivity.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/rag/initialize": {
+      "post": {
+        "summary": "Initialize RAG service",
+        "description": "Initializes RAG components and optionally forces a full refresh.",
+        "tags": [
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "force": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Initialization completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
           }
         }
       }
@@ -968,6 +1346,62 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/playground/bootstrap": {
+      "get": {
+        "summary": "Get playground bootstrap data",
+        "description": "Returns documents and metadata required to initialize the AI playground UI.",
+        "tags": [
+          "Documents",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Playground bootstrap data loaded successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "documents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "tagNames": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "correspondentNames": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
           }
         }
       }
@@ -1872,6 +2306,166 @@
         }
       }
     },
+    "/api/history/{id}/detail": {
+      "get": {
+        "summary": "Get detailed history entry data",
+        "description": "Returns full stored AI output details and a live diff view against current Paperless metadata.",
+        "tags": [
+          "History",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Detailed history data returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document ID"
+          },
+          "404": {
+            "description": "No history entry found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/history/{id}/restore": {
+      "post": {
+        "summary": "Restore document to pre-AI state",
+        "description": "Restores title, tags, correspondent and related metadata from saved original values.",
+        "tags": [
+          "History",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document restored successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document ID"
+          },
+          "404": {
+            "description": "Original data not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/history/{id}/rescan": {
+      "post": {
+        "summary": "Reset one document for reprocessing",
+        "description": "Removes all tracking records for a document so it is processed again in a subsequent scan.",
+        "tags": [
+          "History",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document reset for rescanning",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document ID"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/api/settings/clear-tag-cache": {
       "post": {
         "summary": "Manually clear the centralized tag cache",
@@ -1911,6 +2505,90 @@
           },
           "429": {
             "description": "Too many requests - rate limit exceeded (max 10 requests per 15 minutes)"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/settings/reset-local-overrides": {
+      "post": {
+        "summary": "Reset local runtime overrides",
+        "description": "Removes local runtime override values so injected environment variables are used after restart.",
+        "tags": [
+          "Settings"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Override reset completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "hadOverrides": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/settings/rag-force-model-redownload": {
+      "post": {
+        "summary": "Force RAG model re-download",
+        "description": "Triggers re-download of RAG models in the background.",
+        "tags": [
+          "Settings",
+          "RAG"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Re-download trigger accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           "500": {
             "description": "Server error"
@@ -2151,6 +2829,11 @@
                   "type": "object",
                   "properties": {
                     "success": {
+                      "type": "boolean",
+                      "description": "Indicates whether regeneration succeeded",
+                      "example": true
+                    },
+                    "newKey": {
                       "type": "string",
                       "description": "The newly generated API key",
                       "example": "3f7a8d6e2c1b5a9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f0e9d8c7b6a5"
@@ -3078,6 +3761,39 @@
         }
       }
     },
+    "/api/dashboard/stats": {
+      "get": {
+        "summary": "Get dashboard statistics payload",
+        "description": "Returns all aggregate counters and chart datasets required by the dashboard UI.",
+        "tags": [
+          "System",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dashboard statistics returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/settings": {
       "get": {
         "summary": "Application settings page",
@@ -3374,6 +4090,50 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/settings/paperless-public-url": {
+      "get": {
+        "summary": "Detect Paperless public URL",
+        "description": "Detects and returns the public base URL used for document links.",
+        "tags": [
+          "Settings",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public URL resolved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "publicUrl": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
           }
         }
       }
@@ -4018,6 +4778,520 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/rag-test": {
+      "get": {
+        "summary": "Trigger RAG diagnostic run",
+        "description": "Initializes RAG and attempts to send documents to the RAG service.",
+        "tags": [
+          "RAG",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "RAG diagnostic completed successfully"
+          },
+          "500": {
+            "description": "RAG diagnostic failed"
+          }
+        }
+      }
+    },
+    "/dashboard/doc/{id}": {
+      "get": {
+        "summary": "Redirect to Paperless document details",
+        "tags": [
+          "Navigation",
+          "Documents"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to Paperless document page"
+          },
+          "400": {
+            "description": "Missing document ID"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/ocr": {
+      "get": {
+        "summary": "OCR queue page",
+        "tags": [
+          "Navigation",
+          "OCR"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OCR page rendered successfully",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/failed": {
+      "get": {
+        "summary": "Permanently failed queue page",
+        "tags": [
+          "Navigation",
+          "OCR"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Failed queue page rendered successfully",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/about": {
+      "get": {
+        "summary": "About and support information page",
+        "tags": [
+          "Navigation",
+          "System"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "About page rendered successfully",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/ocr/queue": {
+      "get": {
+        "summary": "Get paginated OCR queue",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OCR queue returned successfully"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/ocr/queue/add": {
+      "post": {
+        "summary": "Add document to OCR queue",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "documentId"
+                ],
+                "properties": {
+                  "documentId": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Add operation result"
+          },
+          "400": {
+            "description": "Invalid payload"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/ocr/queue/{documentId}": {
+      "delete": {
+        "summary": "Remove document from OCR queue",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Remove operation result"
+          },
+          "400": {
+            "description": "Invalid document ID"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/ocr/process/{documentId}": {
+      "post": {
+        "summary": "Process one OCR queue item",
+        "description": "Starts OCR processing for one document and streams progress via SSE.",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream started",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document ID"
+          }
+        }
+      }
+    },
+    "/api/ocr/process-all": {
+      "post": {
+        "summary": "Process all pending OCR queue items",
+        "description": "Starts batch OCR processing and streams progress via SSE.",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream started",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ocr/analyze/{documentId}": {
+      "post": {
+        "summary": "Analyze existing OCR text with AI",
+        "description": "Uses existing OCR text and streams analysis progress via SSE.",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream started",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document ID"
+          }
+        }
+      }
+    },
+    "/api/ocr/queue/{documentId}/text": {
+      "get": {
+        "summary": "Get OCR text for one queue item",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OCR text payload returned"
+          },
+          "400": {
+            "description": "Invalid document ID"
+          },
+          "404": {
+            "description": "Queue item not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/ocr/stats": {
+      "get": {
+        "summary": "Get OCR queue statistics",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OCR statistics returned successfully"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/failed/queue": {
+      "get": {
+        "summary": "Get permanently failed document queue",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Failed queue returned successfully"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/failed/reset/{documentId}": {
+      "post": {
+        "summary": "Reset permanently failed document",
+        "tags": [
+          "OCR",
+          "API"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "documentId",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reset operation result"
+          },
+          "400": {
+            "description": "Invalid document ID"
+          },
+          "500": {
+            "description": "Server error"
           }
         }
       }

--- a/config/config.js
+++ b/config/config.js
@@ -124,6 +124,7 @@ module.exports = {
     return getTrustProxy();
   },
   disableAutomaticProcessing: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
+  exposeApiDocs: parseEnvBoolean(process.env.EXPOSE_API_DOCS, 'no'),
   globalRateLimitWindowMs: parseInt(process.env.GLOBAL_RATE_LIMIT_WINDOW_MS || '900000', 10),
   globalRateLimitMax: parseInt(process.env.GLOBAL_RATE_LIMIT_MAX || '1000', 10),
   predefinedMode: process.env.PROCESS_PREDEFINED_DOCUMENTS,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,15 @@
 services:
   paperless-ai:
-    # Docker Hub (default)
-    image: admonstrator/paperless-ai-next:latest
+    # Local workspace build (default)
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: paperless-ai-next:local
+    pull_policy: never
     
-    # For RAG support, use the full image (~1.5-2 GB):
+    # To use Docker Hub images instead, replace with:
+    # image: admonstrator/paperless-ai-next:latest
+    # or for full RAG image:
     # image: admonstrator/paperless-ai-next:latest-full
     
     container_name: paperless-ai-next

--- a/routes/rag.js
+++ b/routes/rag.js
@@ -4,7 +4,47 @@ const router = express.Router();
 const ragService = require('../services/ragService');
 
 /**
- * Search documents
+ * @swagger
+ * /api/rag/search:
+ *   post:
+ *     summary: Search indexed documents
+ *     description: Performs a hybrid RAG search across indexed documents using the provided query and optional filters.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - query
+ *             properties:
+ *               query:
+ *                 type: string
+ *                 example: "invoice march 2026"
+ *               from_date:
+ *                 type: string
+ *                 format: date
+ *               to_date:
+ *                 type: string
+ *                 format: date
+ *               correspondent:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Search results returned successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       400:
+ *         description: Missing required query
+ *       500:
+ *         description: Internal server error
  */
 router.post('/search', async (req, res) => {
   try {
@@ -28,7 +68,39 @@ router.post('/search', async (req, res) => {
 });
 
 /**
- * Ask a question about documents
+ * @swagger
+ * /api/rag/ask:
+ *   post:
+ *     summary: Ask a question against indexed documents
+ *     description: Returns an AI-generated answer grounded in indexed document content.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - question
+ *             properties:
+ *               question:
+ *                 type: string
+ *                 example: "Which invoices are overdue?"
+ *     responses:
+ *       200:
+ *         description: Answer generated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       400:
+ *         description: Missing required question
+ *       500:
+ *         description: Internal server error
  */
 router.post('/ask', async (req, res) => {
   try {
@@ -47,7 +119,35 @@ router.post('/ask', async (req, res) => {
 });
 
 /**
- * Start document indexing
+ * @swagger
+ * /api/rag/index:
+ *   post:
+ *     summary: Start document indexing
+ *     description: Starts or re-runs indexing in the RAG backend.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               force:
+ *                 type: boolean
+ *                 default: false
+ *     responses:
+ *       200:
+ *         description: Indexing triggered successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       500:
+ *         description: Internal server error
  */
 router.post('/index', async (req, res) => {
   try {
@@ -61,7 +161,25 @@ router.post('/index', async (req, res) => {
 });
 
 /**
- * Get indexing status
+ * @swagger
+ * /api/rag/index/status:
+ *   get:
+ *     summary: Get indexing status
+ *     description: Returns current status information for RAG indexing.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Indexing status returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       500:
+ *         description: Internal server error
  */
 router.get('/index/status', async (req, res) => {
   try {
@@ -74,7 +192,25 @@ router.get('/index/status', async (req, res) => {
 });
 
 /**
- * Check if updates are needed
+ * @swagger
+ * /api/rag/index/check:
+ *   get:
+ *     summary: Check whether re-indexing is required
+ *     description: Compares source state and returns whether RAG index updates are needed.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Check completed successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       500:
+ *         description: Internal server error
  */
 router.get('/index/check', async (req, res) => {
   try {
@@ -87,7 +223,25 @@ router.get('/index/check', async (req, res) => {
 });
 
 /**
- * Get RAG service status
+ * @swagger
+ * /api/rag/status:
+ *   get:
+ *     summary: Get RAG backend status
+ *     description: Returns status details for RAG service and AI backend connectivity.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Status returned successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       500:
+ *         description: Internal server error
  */
 router.get('/status', async (req, res) => {
   try {
@@ -111,7 +265,35 @@ router.get('/status', async (req, res) => {
 });
 
 /**
- * Initialize RAG service
+ * @swagger
+ * /api/rag/initialize:
+ *   post:
+ *     summary: Initialize RAG service
+ *     description: Initializes RAG components and optionally forces a full refresh.
+ *     tags:
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               force:
+ *                 type: boolean
+ *                 default: false
+ *     responses:
+ *       200:
+ *         description: Initialization completed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       500:
+ *         description: Internal server error
  */
 router.post('/initialize', async (req, res) => {
   try {

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -630,6 +630,44 @@ router.get('/api/playground/bootstrap', protectApiRoute, async (req, res) => {
 
 /**
  * @swagger
+ * /api/playground/bootstrap:
+ *   get:
+ *     summary: Get playground bootstrap data
+ *     description: Returns documents and metadata required to initialize the AI playground UI.
+ *     tags:
+ *       - Documents
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Playground bootstrap data loaded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 documents:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                 tagNames:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                 correspondentNames:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *       500:
+ *         description: Server error
+ */
+
+/**
+ * @swagger
  * /thumb/{documentId}:
  *   get:
  *     summary: Get document thumbnail
@@ -1559,9 +1597,36 @@ router.post('/api/history/clear-cache', isAuthenticated, cacheClearLimiter, asyn
 });
 
 /**
- * GET /api/history/:id/detail
- * Returns full AI analysis details for a single document from history,
- * including a live tag diff against the current state in Paperless-ngx.
+ * @swagger
+ * /api/history/{id}/detail:
+ *   get:
+ *     summary: Get detailed history entry data
+ *     description: Returns full stored AI output details and a live diff view against current Paperless metadata.
+ *     tags:
+ *       - History
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Detailed history data returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       400:
+ *         description: Invalid document ID
+ *       404:
+ *         description: No history entry found
+ *       500:
+ *         description: Server error
  */
 router.get('/api/history/:id/detail', isAuthenticated, async (req, res) => {
   try {
@@ -1664,9 +1729,41 @@ router.get('/api/history/:id/detail', isAuthenticated, async (req, res) => {
 });
 
 /**
- * POST /api/history/:id/restore
- * Restores a document in Paperless-ngx to its original (pre-AI) state
- * using the saved original_documents data.
+ * @swagger
+ * /api/history/{id}/restore:
+ *   post:
+ *     summary: Restore document to pre-AI state
+ *     description: Restores title, tags, correspondent and related metadata from saved original values.
+ *     tags:
+ *       - History
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Document restored successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Invalid document ID
+ *       404:
+ *         description: Original data not found
+ *       500:
+ *         description: Server error
  */
 router.post('/api/history/:id/restore', isAuthenticated, async (req, res) => {
   try {
@@ -1708,10 +1805,39 @@ router.post('/api/history/:id/restore', isAuthenticated, async (req, res) => {
 });
 
 /**
- * POST /api/history/:id/rescan
- * Removes a document from all tracking tables so it will be picked up
- * on the next scan. Returns immediately; the actual rescan is triggered
- * separately via POST /api/scan/now.
+ * @swagger
+ * /api/history/{id}/rescan:
+ *   post:
+ *     summary: Reset one document for reprocessing
+ *     description: Removes all tracking records for a document so it is processed again in a subsequent scan.
+ *     tags:
+ *       - History
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Document reset for rescanning
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Invalid document ID
+ *       500:
+ *         description: Server error
  */
 router.post('/api/history/:id/rescan', isAuthenticated, async (req, res) => {
   try {
@@ -1779,6 +1905,35 @@ router.post('/api/settings/clear-tag-cache', isAuthenticated, cacheClearLimiter,
   }
 });
 
+/**
+ * @swagger
+ * /api/settings/reset-local-overrides:
+ *   post:
+ *     summary: Reset local runtime overrides
+ *     description: Removes local runtime override values so injected environment variables are used after restart.
+ *     tags:
+ *       - Settings
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Override reset completed
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 hadOverrides:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *       500:
+ *         description: Server error
+ */
+
 router.post('/api/settings/reset-local-overrides', isAuthenticated, cacheClearLimiter, async (req, res) => {
   try {
     const hadOverrides = await setupService.clearRuntimeOverrides();
@@ -1798,6 +1953,34 @@ router.post('/api/settings/reset-local-overrides', isAuthenticated, cacheClearLi
     });
   }
 });
+
+/**
+ * @swagger
+ * /api/settings/rag-force-model-redownload:
+ *   post:
+ *     summary: Force RAG model re-download
+ *     description: Triggers re-download of RAG models in the background.
+ *     tags:
+ *       - Settings
+ *       - RAG
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Re-download trigger accepted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *       500:
+ *         description: Server error
+ */
 
 router.post('/api/settings/rag-force-model-redownload', isAuthenticated, cacheClearLimiter, async (req, res) => {
   try {
@@ -3319,6 +3502,29 @@ router.get('/api/dashboard/stats', async (req, res) => {
 
 /**
  * @swagger
+ * /api/dashboard/stats:
+ *   get:
+ *     summary: Get dashboard statistics payload
+ *     description: Returns all aggregate counters and chart datasets required by the dashboard UI.
+ *     tags:
+ *       - System
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Dashboard statistics returned successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *       500:
+ *         description: Server error
+ */
+
+/**
+ * @swagger
  * /settings:
  *   get:
  *     summary: Application settings page
@@ -3527,6 +3733,36 @@ router.get('/api/settings/paperless-public-url', isAuthenticated, async (req, re
     return res.status(500).json({ success: false, error: 'Failed to detect Paperless public URL' });
   }
 });
+
+/**
+ * @swagger
+ * /api/settings/paperless-public-url:
+ *   get:
+ *     summary: Detect Paperless public URL
+ *     description: Detects and returns the public base URL used for document links.
+ *     tags:
+ *       - Settings
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Public URL resolved
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 publicUrl:
+ *                   type: string
+ *                 source:
+ *                   type: string
+ *       500:
+ *         description: Server error
+ */
 
 /**
  * @swagger
@@ -5249,6 +5485,25 @@ router.get('/api/rag-test', async (req, res) => {
 }
 );
 
+/**
+ * @swagger
+ * /api/rag-test:
+ *   get:
+ *     summary: Trigger RAG diagnostic run
+ *     description: Initializes RAG and attempts to send documents to the RAG service.
+ *     tags:
+ *       - RAG
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: RAG diagnostic completed successfully
+ *       500:
+ *         description: RAG diagnostic failed
+ */
+
 router.get('/dashboard/doc/:id', async (req, res) => {
   const docId = req.params.id;
   if (!docId) {
@@ -5269,6 +5524,32 @@ router.get('/dashboard/doc/:id', async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /dashboard/doc/{id}:
+ *   get:
+ *     summary: Redirect to Paperless document details
+ *     tags:
+ *       - Navigation
+ *       - Documents
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       302:
+ *         description: Redirect to Paperless document page
+ *       400:
+ *         description: Missing document ID
+ *       500:
+ *         description: Server error
+ */
+
 // ─── OCR Queue Routes ─────────────────────────────────────────────────────
 
 // Page: OCR Queue UI
@@ -5286,6 +5567,28 @@ router.get('/ocr', protectApiRoute, async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /ocr:
+ *   get:
+ *     summary: OCR queue page
+ *     tags:
+ *       - Navigation
+ *       - OCR
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: OCR page rendered successfully
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ *       500:
+ *         description: Server error
+ */
+
 // Page: Permanently Failed UI
 router.get('/failed', protectApiRoute, async (req, res) => {
   try {
@@ -5299,6 +5602,28 @@ router.get('/failed', protectApiRoute, async (req, res) => {
     res.status(500).json({ success: false, error: error.message });
   }
 });
+
+/**
+ * @swagger
+ * /failed:
+ *   get:
+ *     summary: Permanently failed queue page
+ *     tags:
+ *       - Navigation
+ *       - OCR
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Failed queue page rendered successfully
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ *       500:
+ *         description: Server error
+ */
 
 // Page: About / Support Information
 router.get('/about', protectApiRoute, async (req, res) => {
@@ -5362,6 +5687,28 @@ router.get('/about', protectApiRoute, async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /about:
+ *   get:
+ *     summary: About and support information page
+ *     tags:
+ *       - Navigation
+ *       - System
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: About page rendered successfully
+ *         content:
+ *           text/html:
+ *             schema:
+ *               type: string
+ *       500:
+ *         description: Server error
+ */
+
 // API: Get paginated queue
 router.get('/api/ocr/queue', isAuthenticated, async (req, res) => {
   try {
@@ -5391,6 +5738,24 @@ router.get('/api/ocr/queue', isAuthenticated, async (req, res) => {
     res.status(500).json({ success: false, error: error.message });
   }
 });
+
+/**
+ * @swagger
+ * /api/ocr/queue:
+ *   get:
+ *     summary: Get paginated OCR queue
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: OCR queue returned successfully
+ *       500:
+ *         description: Server error
+ */
 
 // API: Add a document manually to OCR queue
 router.post('/api/ocr/queue/add', isAuthenticated, async (req, res) => {
@@ -5422,6 +5787,37 @@ router.post('/api/ocr/queue/add', isAuthenticated, async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/ocr/queue/add:
+ *   post:
+ *     summary: Add document to OCR queue
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - documentId
+ *             properties:
+ *               documentId:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Add operation result
+ *       400:
+ *         description: Invalid payload
+ *       500:
+ *         description: Server error
+ */
+
 // API: Remove a document from OCR queue
 router.delete('/api/ocr/queue/:documentId', isAuthenticated, async (req, res) => {
   try {
@@ -5436,6 +5832,32 @@ router.delete('/api/ocr/queue/:documentId', isAuthenticated, async (req, res) =>
     res.status(500).json({ success: false, error: error.message });
   }
 });
+
+/**
+ * @swagger
+ * /api/ocr/queue/{documentId}:
+ *   delete:
+ *     summary: Remove document from OCR queue
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: documentId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Remove operation result
+ *       400:
+ *         description: Invalid document ID
+ *       500:
+ *         description: Server error
+ */
 
 // API: Process a single document with Mistral OCR (SSE)
 router.post('/api/ocr/process/:documentId', isAuthenticated, async (req, res) => {
@@ -5478,6 +5900,35 @@ router.post('/api/ocr/process/:documentId', isAuthenticated, async (req, res) =>
 
   res.end();
 });
+
+/**
+ * @swagger
+ * /api/ocr/process/{documentId}:
+ *   post:
+ *     summary: Process one OCR queue item
+ *     description: Starts OCR processing for one document and streams progress via SSE.
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: documentId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: SSE stream started
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               type: string
+ *       400:
+ *         description: Invalid document ID
+ */
 
 // API: Process all pending items in OCR queue (SSE)
 router.post('/api/ocr/process-all', isAuthenticated, async (req, res) => {
@@ -5541,6 +5992,27 @@ router.post('/api/ocr/process-all', isAuthenticated, async (req, res) => {
   res.end();
 });
 
+/**
+ * @swagger
+ * /api/ocr/process-all:
+ *   post:
+ *     summary: Process all pending OCR queue items
+ *     description: Starts batch OCR processing and streams progress via SSE.
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: SSE stream started
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               type: string
+ */
+
 // API: Trigger AI-only analysis from existing OCR text (SSE)
 router.post('/api/ocr/analyze/:documentId', isAuthenticated, async (req, res) => {
   const documentId = parseInt(req.params.documentId, 10);
@@ -5581,6 +6053,35 @@ router.post('/api/ocr/analyze/:documentId', isAuthenticated, async (req, res) =>
   res.end();
 });
 
+/**
+ * @swagger
+ * /api/ocr/analyze/{documentId}:
+ *   post:
+ *     summary: Analyze existing OCR text with AI
+ *     description: Uses existing OCR text and streams analysis progress via SSE.
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: documentId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: SSE stream started
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               type: string
+ *       400:
+ *         description: Invalid document ID
+ */
+
 // API: Get OCR text for a queue item
 router.get('/api/ocr/queue/:documentId/text', isAuthenticated, async (req, res) => {
   try {
@@ -5609,6 +6110,34 @@ router.get('/api/ocr/queue/:documentId/text', isAuthenticated, async (req, res) 
   }
 });
 
+/**
+ * @swagger
+ * /api/ocr/queue/{documentId}/text:
+ *   get:
+ *     summary: Get OCR text for one queue item
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: documentId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: OCR text payload returned
+ *       400:
+ *         description: Invalid document ID
+ *       404:
+ *         description: Queue item not found
+ *       500:
+ *         description: Server error
+ */
+
 // API: Get OCR queue statistics
 router.get('/api/ocr/stats', isAuthenticated, async (req, res) => {
   try {
@@ -5628,6 +6157,24 @@ router.get('/api/ocr/stats', isAuthenticated, async (req, res) => {
     res.status(500).json({ success: false, error: error.message });
   }
 });
+
+/**
+ * @swagger
+ * /api/ocr/stats:
+ *   get:
+ *     summary: Get OCR queue statistics
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: OCR statistics returned successfully
+ *       500:
+ *         description: Server error
+ */
 
 // API: Get paginated permanently failed documents queue
 router.get('/api/failed/queue', isAuthenticated, async (req, res) => {
@@ -5657,6 +6204,24 @@ router.get('/api/failed/queue', isAuthenticated, async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/failed/queue:
+ *   get:
+ *     summary: Get permanently failed document queue
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Failed queue returned successfully
+ *       500:
+ *         description: Server error
+ */
+
 // API: Reset terminal failure state for a document
 router.post('/api/failed/reset/:documentId', isAuthenticated, async (req, res) => {
   try {
@@ -5679,5 +6244,31 @@ router.post('/api/failed/reset/:documentId', isAuthenticated, async (req, res) =
     return res.status(500).json({ success: false, error: error.message });
   }
 });
+
+/**
+ * @swagger
+ * /api/failed/reset/{documentId}:
+ *   post:
+ *     summary: Reset permanently failed document
+ *     tags:
+ *       - OCR
+ *       - API
+ *     security:
+ *       - BearerAuth: []
+ *       - ApiKeyAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: documentId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Reset operation result
+ *       400:
+ *         description: Invalid document ID
+ *       500:
+ *         description: Server error
+ */
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -18,12 +18,11 @@ const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const { doubleCsrf } = require('csrf-csrf');
 const rateLimit = require('express-rate-limit');
+const { ipKeyGenerator } = require('express-rate-limit');
 const jwt = require('jsonwebtoken');
 const Logger = require('./services/loggerService');
 const { max } = require('date-fns');
 const { validateCustomFieldValue, shouldQueueForOcrOnAiError, classifyOcrQueueReasonFromAiError } = require('./services/serviceUtils');
-const swaggerUi = require('swagger-ui-express');
-const swaggerSpec = require('./swagger');
 const dataDir = path.join(process.cwd(), 'data');
 const openApiDir = path.join(dataDir, 'OPENAPI');
 const openApiPath = path.join(openApiDir, 'openapi.json');
@@ -110,7 +109,7 @@ const apiGlobalLimiter = rateLimit({
       }
     }
 
-    return req.ip;
+    return ipKeyGenerator(req.ip);
   }
 });
 
@@ -185,73 +184,97 @@ app.use((req, res, next) => {
 
 app.use(['/api', '/chat', '/manual'], apiGlobalLimiter);
 
-// Swagger documentation route (protected)
-app.use('/api-docs', isAuthenticated, swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
-  swaggerOptions: {
-    url: '/api-docs/openapi.json'
-  }
-}));
+const isApiDocsEnabled = config.exposeApiDocs === 'yes';
+let swaggerSpec = null;
 
-/**
- * @swagger
- * /api-docs/openapi.json:
- *   get:
- *     summary: Retrieve the OpenAPI specification
- *     description: |
- *       Returns the complete OpenAPI specification for the Paperless-AI next API.
- *       This endpoint attempts to serve a static OpenAPI JSON file first, falling back
- *       to dynamically generating the specification if the file cannot be read.
- *       
- *       The OpenAPI specification document contains all API endpoints, parameters,
- *       request bodies, responses, and schemas for the entire application.
- *     tags: [API, System]
- *     responses:
- *       200:
- *         description: OpenAPI specification returned successfully
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               description: The complete OpenAPI specification
- *       302:
- *         description: Redirect to login when authentication is missing or invalid
- *         headers:
- *           Location:
- *             schema:
- *               type: string
- *               example: /login
- *       404:
- *         description: OpenAPI specification file not found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- *       500:
- *         description: Server error occurred while retrieving the OpenAPI specification
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
- */
-app.get('/api-docs/openapi.json', isAuthenticated, (req, res) => {
-  res.setHeader('Content-Type', 'application/json');
-  
-  // Try to serve the static file first
-  fs.readFile(openApiPath)
-    .then(data => {
-      res.send(JSON.parse(data));
-    })
-    .catch(err => {
-      console.warn('Error reading OpenAPI file, generating dynamically:', err.message);
-      // Fallback to generating the spec if file can't be read
-      res.send(swaggerSpec);
-    });
-});
+if (isApiDocsEnabled) {
+  const swaggerUi = require('swagger-ui-express');
+  swaggerSpec = require('./swagger');
 
-// Add a redirect for the old endpoint for backward compatibility
-app.get('/api-docs.json', isAuthenticated, (req, res) => {
-  res.redirect('/api-docs/openapi.json');
-});
+  // Swagger documentation route (protected)
+  app.use('/api-docs', isAuthenticated, swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
+    swaggerOptions: {
+      url: '/api-docs/openapi.json'
+    }
+  }));
+
+  /**
+   * @swagger
+   * /api-docs/openapi.json:
+   *   get:
+   *     summary: Retrieve the OpenAPI specification
+   *     description: |
+   *       Returns the complete OpenAPI specification for the Paperless-AI next API.
+   *       This endpoint attempts to serve a static OpenAPI JSON file first, falling back
+   *       to dynamically generating the specification if the file cannot be read.
+   *       
+   *       The OpenAPI specification document contains all API endpoints, parameters,
+   *       request bodies, responses, and schemas for the entire application.
+   *     tags: [API, System]
+   *     responses:
+   *       200:
+   *         description: OpenAPI specification returned successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               description: The complete OpenAPI specification
+   *       302:
+   *         description: Redirect to login when authentication is missing or invalid
+   *         headers:
+   *           Location:
+   *             schema:
+   *               type: string
+   *               example: /login
+   *       404:
+   *         description: OpenAPI specification file not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   *       500:
+   *         description: Server error occurred while retrieving the OpenAPI specification
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   */
+  app.get('/api-docs/openapi.json', isAuthenticated, (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    
+    // Try to serve the static file first
+    fs.readFile(openApiPath)
+      .then(data => {
+        res.send(JSON.parse(data));
+      })
+      .catch(err => {
+        console.warn('Error reading OpenAPI file, generating dynamically:', err.message);
+        // Fallback to generating the spec if file can't be read
+        res.send(swaggerSpec);
+      });
+  });
+
+  /**
+   * @swagger
+   * /api-docs.json:
+   *   get:
+   *     summary: Redirect to OpenAPI specification endpoint
+   *     description: Backward-compatible redirect to `/api-docs/openapi.json`.
+   *     tags:
+   *       - API
+   *       - System
+   *     security:
+   *       - BearerAuth: []
+   *       - ApiKeyAuth: []
+   *     responses:
+   *       302:
+   *         description: Redirects to `/api-docs/openapi.json`
+   */
+  // Add a redirect for the old endpoint for backward compatibility
+  app.get('/api-docs.json', isAuthenticated, (req, res) => {
+    res.redirect('/api-docs/openapi.json');
+  });
+}
 
 // View engine setup
 app.set('view engine', 'ejs');
@@ -282,6 +305,10 @@ async function initializeDataDirectory() {
 
 // Save OpenAPI specification to file
 async function saveOpenApiSpec() {
+  if (!isApiDocsEnabled || !swaggerSpec) {
+    return true;
+  }
+
   try {
     // Ensure the directory exists
     try {
@@ -638,6 +665,29 @@ const ragRoutes = require('./routes/rag');
 // Mount RAG routes if enabled
 if (process.env.RAG_SERVICE_ENABLED === 'true') {
   app.use('/api/rag', isAuthenticated, ragRoutes);
+
+  /**
+   * @swagger
+   * /rag:
+   *   get:
+   *     summary: RAG chat interface page
+   *     description: Renders the RAG interface for asking questions against indexed documents.
+   *     tags:
+   *       - Navigation
+   *       - RAG
+   *     security:
+   *       - BearerAuth: []
+   *       - ApiKeyAuth: []
+   *     responses:
+   *       200:
+   *         description: RAG page rendered successfully
+   *         content:
+   *           text/html:
+   *             schema:
+   *               type: string
+   *       500:
+   *         description: Server error
+   */
   
   // RAG UI route
   app.get('/rag', isAuthenticated, async (req, res) => {

--- a/swagger.js
+++ b/swagger.js
@@ -1,4 +1,8 @@
+const fs = require('fs');
+const path = require('path');
 const swaggerJSDoc = require('swagger-jsdoc');
+
+const bundledOpenApiPath = path.join(__dirname, 'OPENAPI', 'openapi.json');
 
 const swaggerDefinition = {
   openapi: '3.0.0',
@@ -49,6 +53,22 @@ const options = {
   apis: ['./server.js', './routes/*.js', './schemas.js'], // Path to the API docs
 };
 
-const swaggerSpec = swaggerJSDoc(options);
+function loadBundledOpenApiSpec() {
+  try {
+    const fileContent = fs.readFileSync(bundledOpenApiPath, 'utf8');
+    return JSON.parse(fileContent);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      console.warn(`Could not load bundled OpenAPI spec from ${bundledOpenApiPath}: ${error.message}`);
+    }
+    return null;
+  }
+}
+
+function generateOpenApiSpec() {
+  return swaggerJSDoc(options);
+}
+
+const swaggerSpec = loadBundledOpenApiSpec() || generateOpenApiSpec();
 
 module.exports = swaggerSpec;


### PR DESCRIPTION
- Added `exposeApiDocs` configuration option to enable or disable API documentation exposure.
- Updated `docker-compose.yml` to support local builds for the Paperless-AI service.
- Enhanced RAG routes with Swagger documentation for search, ask, index, and status endpoints.
- Added Swagger documentation for playground bootstrap, history detail, restore, and rescan endpoints.
- Introduced Swagger documentation for settings reset and RAG model re-download endpoints.
- Implemented Swagger documentation for dashboard statistics and Paperless public URL detection.
- Added Swagger documentation for OCR queue operations, including add, remove, process, and analyze.
- Updated server.js to conditionally serve Swagger UI based on configuration.
- Refactored OpenAPI specification loading logic in swagger.js to support bundled specs.