### PR TITLE
Update versioning format to vYYYY.MM.## style

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,7 +72,7 @@ body:
   attributes:
     label: Paperless-AI next version
     description: Version shown in the app/footer or image tag used.
-    placeholder: "e.g. v2026-03-01-04"
+    placeholder: "e.g. v2026.03.01"
   validations:
     required: true
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       manual_version:
-        description: 'Manual version/tag to use (e.g. v2026-03-05-01 or v2.4.0)'
+        description: 'Manual version/tag to use (e.g. v2026.03.01 or v2.4.0)'
         required: false
         default: ''
         type: string
@@ -54,14 +54,19 @@ jobs:
             BASE_VERSION="$MANUAL_VERSION"
             echo "Using manual version tag: $VERSION_TAG"
           else
-            # Use today's date as version base: vYYYY-MM-DD
-            DATE_PREFIX="v$(date +%Y-%m-%d)"
-            BASE_VERSION="$DATE_PREFIX"
-            echo "Date prefix: $DATE_PREFIX"
+            # Use current month as version base: vYYYY.MM
+            MONTH_PREFIX="v$(date +%Y.%m)"
+            BASE_VERSION="$MONTH_PREFIX"
+            echo "Month prefix: $MONTH_PREFIX"
 
-            # Find highest build number for today's date
+            # Find highest build number for current month
             git fetch --tags
-            LATEST_BUILD=$(git tag -l "${DATE_PREFIX}-*" | sed "s/${DATE_PREFIX}-//" | grep '^[0-9]\+$' | sort -n | tail -1)
+            ESCAPED_MONTH_PREFIX="${MONTH_PREFIX//./\\.}"
+            LATEST_BUILD=$(git tag -l "${MONTH_PREFIX}.*" \
+              | grep -E "^${ESCAPED_MONTH_PREFIX}\.[0-9]+$" \
+              | sed -E "s/^${ESCAPED_MONTH_PREFIX}\.//" \
+              | sort -n \
+              | tail -1)
 
             # Increment or start at 01
             if [ -z "$LATEST_BUILD" ]; then
@@ -70,7 +75,7 @@ jobs:
               BUILD_NUMBER=$(printf "%02d" $((10#$LATEST_BUILD + 1)))
             fi
 
-            VERSION_TAG="${DATE_PREFIX}-${BUILD_NUMBER}"
+            VERSION_TAG="${MONTH_PREFIX}.${BUILD_NUMBER}"
             echo "Generated version tag: $VERSION_TAG"
           fi
 

--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -78,18 +78,18 @@ jobs:
           # Always protect these exact tags
           PROTECTED_TAGS="latest latest-lite latest-full latest-base-lite latest-base-full"
 
-          # Get versioned lite tags (e.g. v2026-02-27-01-lite), sorted by push date desc
-          lite_tags=$(jq -r '[.[] | select(.name | test("^v[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-lite$"))] | sort_by(.last_pushed) | reverse | .['"$KEEP_COUNT"':] | .[].name' /tmp/all_tags.json)
+          # Get versioned lite tags (new: v2026.03.01-lite, legacy: v2026-03-07-01-lite), sorted by push date desc
+          lite_tags=$(jq -r '[.[] | select(.name | test("^(v[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+|v[0-9]{4}\\.[0-9]{2}\\.[0-9]+)-lite$"))] | sort_by(.last_pushed) | reverse | .['"$KEEP_COUNT"':] | .[].name' /tmp/all_tags.json)
           echo "🔵 Lite tags to delete: $(echo "$lite_tags" | grep '.' | wc -l)"
           [ -n "$lite_tags" ] && echo "$lite_tags" || true
 
-          # Get versioned full tags (e.g. v2026-02-27-01-full), sorted by push date desc
-          full_tags=$(jq -r '[.[] | select(.name | test("^v[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+-full$"))] | sort_by(.last_pushed) | reverse | .['"$KEEP_COUNT"':] | .[].name' /tmp/all_tags.json)
+          # Get versioned full tags (new: v2026.03.01-full, legacy: v2026-03-07-01-full), sorted by push date desc
+          full_tags=$(jq -r '[.[] | select(.name | test("^(v[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+|v[0-9]{4}\\.[0-9]{2}\\.[0-9]+)-full$"))] | sort_by(.last_pushed) | reverse | .['"$KEEP_COUNT"':] | .[].name' /tmp/all_tags.json)
           echo "🟢 Full tags to delete: $(echo "$full_tags" | grep '.' | wc -l)"
           [ -n "$full_tags" ] && echo "$full_tags" || true
 
-          # Get plain versioned tags (e.g. v2026-02-27-01), sorted by push date desc
-          version_tags=$(jq -r '[.[] | select(.name | test("^v[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+$"))] | sort_by(.last_pushed) | reverse | .['"$KEEP_COUNT"':] | .[].name' /tmp/all_tags.json)
+          # Get plain versioned tags (new: v2026.03.01, legacy: v2026-03-07-01), sorted by push date desc
+          version_tags=$(jq -r '[.[] | select(.name | test("^(v[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]+|v[0-9]{4}\\.[0-9]{2}\\.[0-9]+)$"))] | sort_by(.last_pushed) | reverse | .['"$KEEP_COUNT"':] | .[].name' /tmp/all_tags.json)
           echo "🟡 Plain versioned tags to delete: $(echo "$version_tags" | grep '.' | wc -l)"
           [ -n "$version_tags" ] && echo "$version_tags" || true
 

--- a/.github/workflows/revert-version.yml
+++ b/.github/workflows/revert-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to remove (e.g. v2026-03-05-01 or 2026-03-05-01)'
+        description: 'Version to remove (e.g. v2026.03.01 or 2026.03.01; legacy v2026-03-05-01 also works)'
         required: true
         type: string
       delete_github_release:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Then open [http://localhost:3000](http://localhost:3000) to complete setup.
 
 **Docker Hub:** [admonstrator/paperless-ai-next](https://hub.docker.com/r/admonstrator/paperless-ai-next)
 
+Versioned release tags use the format `vYYYY.MM.##` (example: `v2026.03.01`, plus `-lite`/`-full` variants).
+
 ---
 
 ## ℹ️ More

--- a/config/config.js
+++ b/config/config.js
@@ -109,7 +109,7 @@ console.log('Loaded environment variables:', {
 });
 
 module.exports = {
-  PAPERLESS_AI_VERSION: 'v2026-03-07-01',
+  PAPERLESS_AI_VERSION: 'v2026.03.01',
   CONFIGURED: false,
   getApiKey,
   getJwtSecret,

--- a/readme.template.md
+++ b/readme.template.md
@@ -142,6 +142,8 @@ Then open [http://localhost:3000](http://localhost:3000) to complete setup.
 
 **Docker Hub:** [admonstrator/paperless-ai-next](https://hub.docker.com/r/admonstrator/paperless-ai-next)
 
+Versioned release tags use the format `vYYYY.MM.##` (example: `v2026.03.01`, plus `-lite`/`-full` variants).
+
 ---
 
 ## ℹ️ More


### PR DESCRIPTION
Change the versioning format across workflows and documentation to use `vYYYY.MM.##` style, enhancing consistency and clarity in version representation. Update related descriptions and examples accordingly.