### PR TITLE
fix: reconcile stale documents from AI database on each scan cycle

### DIFF
--- a/server.js
+++ b/server.js
@@ -809,6 +809,18 @@ async function scanInitial() {
     // Extract tag names from tag objects
     const existingTagNames = existingTags.map(tag => tag.name);
 
+    // Reconcile: remove stale entries for documents deleted in Paperless-ngx
+    const validIdSet = new Set(documents.map(d => d.id));
+    const processedDocs = await documentModel.getProcessedDocuments();
+    const staleIds = processedDocs
+        .map(d => d.document_id)
+        .filter(id => !validIdSet.has(id));
+
+    if (staleIds.length > 0) {
+      await documentModel.deleteDocumentsIdList(staleIds);
+      console.log(`[DEBUG] Reconciled: removed ${staleIds.length} stale entries from AI database`);
+    }
+
     for (const doc of documents) {
       try {
         const result = await processDocument(doc, existingTagNames, existingCorrespondentList, existingDocumentTypesList, ownUserId);
@@ -871,6 +883,18 @@ async function scanDocuments(source = 'scheduler') {
 
     // Extract tag names from tag objects
     const existingTagNames = existingTags.map((tag) => tag.name);
+
+    // Reconcile: remove stale entries for documents deleted in Paperless-ngx
+    const validIdSet = new Set(documents.map(d => d.id));
+    const processedDocs = await documentModel.getProcessedDocuments();
+    const staleIds = processedDocs
+        .map(d => d.document_id)
+        .filter(id => !validIdSet.has(id));
+
+    if (staleIds.length > 0) {
+      await documentModel.deleteDocumentsIdList(staleIds);
+      console.log(`[DEBUG] Reconciled: removed ${staleIds.length} stale entries from AI database`);
+    }
 
     for (const doc of documents) {
       if (scanControl.stopRequested) {


### PR DESCRIPTION
## Summary

Fixes #69

When documents are deleted in Paperless-ngx, the AI's local SQLite tables still hold entries for those deleted docs, causing the unprocessed count to go negative and stale data to persist.

Adds a reconciliation step at the start of `scanInitial()` and `scanDocuments()` that diffs the valid document IDs (already fetched via `getAllDocuments()`) against `processed_documents` and removes stale entries using the existing `deleteDocumentsIdList()`.

No new API calls, no new dependencies. Set lookup is O(n), only stale IDs (typically a handful) go to the delete method.

## Tested

50-doc QA setup: deleted 3 docs from Paperless-ngx, restarted AI. Log shows `Reconciled: removed 3 stale entries from AI database`. Count correct, processing unaffected.