### PR TITLE
fix: normalize API URL to prevent double /api/ paths

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -38,8 +38,10 @@ class PaperlessService {
 
   initialize() {
     if (!this.client && config.paperless.apiUrl && config.paperless.apiToken) {
+      // Normalize URL to avoid double /api/ paths when setup wizard appends /api
+      const baseURL = config.paperless.apiUrl.replace(/\/+$/, '').replace(/\/api$/, '') + '/api';
       this.client = axios.create({
-        baseURL: config.paperless.apiUrl,
+        baseURL,
         headers: {
           'Authorization': `Token ${config.paperless.apiToken}`,
           'Content-Type': 'application/json'
@@ -306,8 +308,9 @@ class PaperlessService {
     }
 
   async initializeWithCredentials(apiUrl, apiToken) {
+    const baseURL = apiUrl.replace(/\/+$/, '').replace(/\/api$/, '') + '/api';
     this.client = axios.create({
-      baseURL: apiUrl,
+      baseURL,
       headers: {
         'Authorization': `Token ${apiToken}`,
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary

Fixes #70

`initialize()` uses `config.paperless.apiUrl` as the axios `baseURL` without normalizing. If the URL includes a trailing `/api` (which the setup wizard adds), all endpoint paths become `/api/api/`.

Both `initialize()` and `initializeWithCredentials()` now strip trailing `/api` before re-adding it. Idempotent — works whether the URL has `/api` or not.

```javascript
const baseURL = apiUrl.replace(/\/api\/?$/, '') + '/api';
```