### PR TITLE
fix: skip custom field values exceeding 128-character limit

### DIFF
--- a/services/serviceUtils.js
+++ b/services/serviceUtils.js
@@ -508,6 +508,14 @@ function validateCustomFieldValue(fieldName, rawValue, dataType) {
         };
     }
 
+    // Paperless-ngx enforces a 128-character limit on STRING custom fields
+    if (dataType === 'string' && strValue.length > 128) {
+        return {
+            skip: true,
+            warn: `[WARN] Custom field "${fieldName}" value exceeds 128 characters (${strValue.length}), skipping`
+        };
+    }
+
     // All other types: pass the string through unchanged
     return { skip: false, value: strValue };
 }


### PR DESCRIPTION
## Summary

Fixes #78

Paperless-ngx rejects STRING custom fields longer than 128 characters with `400 Bad Request`, causing the entire document update to fail — tags, title, correspondent all lost.

Added a length check to `validateCustomFieldValue()` in `serviceUtils.js`, matching the existing skip+warn pattern for invalid date and boolean values. Fields exceeding 128 chars are skipped and a warning is logged:

```
[WARN] Custom field "FieldName" value exceeds 128 characters (200), skipping
```

This keeps the document update intact while alerting the operator that a field was dropped.

## Changes

- `services/serviceUtils.js`: Added string length validation in `validateCustomFieldValue()`

## Tested

QA instance: created a STRING custom field, confirmed Paperless-ngx returns 400 for values > 128 chars. With the fix, documents process successfully — the oversized field is skipped with a warning, all other metadata saved.