### PR TITLE
fix: skip invalid and future dates instead of 1990 fallback

### DIFF
--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1760,38 +1760,42 @@ async getOrCreateDocumentType(name, options = {}) {
       }
 
       let updateData;
+      // Remove null/undefined dates before processing
+      if (updates.created === null || updates.created === undefined) {
+        delete updates.created;
+      }
       try {
         if (updates.created) {
           let dateObject;
-          
+
           dateObject = parseISO(updates.created);
-          
+
           if (!isValid(dateObject)) {
             dateObject = parse(updates.created, 'dd.MM.yyyy', new Date());
             if (!isValid(dateObject)) {
               dateObject = parse(updates.created, 'dd-MM-yyyy', new Date());
             }
           }
-          
+
           if (!isValid(dateObject)) {
-            console.warn(`[WARN] Invalid date format: ${updates.created}, using fallback date: 01.01.1990`);
-            dateObject = new Date(1990, 0, 1);
+            console.warn(`[WARN] Invalid date format: ${updates.created}, skipping date update`);
+            delete updates.created;
+          } else if (dateObject > new Date()) {
+            console.warn(`[WARN] AI returned future date ${format(dateObject, 'yyyy-MM-dd')}, skipping date update`);
+            delete updates.created;
+          } else {
+            updates.created = format(dateObject, 'yyyy-MM-dd');
           }
-      
-          updateData = {
-            ...updates,
-            created: format(dateObject, 'yyyy-MM-dd'),
-          };
+
+          updateData = { ...updates };
         } else {
           updateData = { ...updates };
         }
       } catch (error) {
         console.warn('[WARN] Error parsing date:', error.message);
         console.warn('[DEBUG] Received Date:', updates);
-        updateData = {
-          ...updates,
-          created: format(new Date(1990, 0, 1), 'yyyy-MM-dd'),
-        };
+        delete updates.created;
+        updateData = { ...updates };
       }
 
       // // Handle custom fields update


### PR DESCRIPTION
## Summary

Fixes #80

When the AI returns an unparseable or future date, the code overwrites the document's created date with 1990-01-01. Now it skips the date field entirely, preserving the original date from Paperless-ngx.

## Changes

- `services/paperlessService.js`: Replace 1990 fallback with `delete updates.created` for invalid dates, future dates, and parse errors

## Tested

QA instance: doc 34 had AI-assigned future date 2026-06-05. After fix: `[WARN] AI returned future date 2026-06-05, skipping date update` — doc processed successfully, original date preserved.