### PR TITLE
fix: sanitize documentId in thumbnail cache path

### DIFF
--- a/services/thumbnailCachePaths.js
+++ b/services/thumbnailCachePaths.js
@@ -4,7 +4,14 @@ const THUMBNAIL_CACHE_DIR = path.join(process.cwd(), 'data', 'thumb-cache');
 const LEGACY_PUBLIC_THUMBNAIL_CACHE_DIR = path.join(process.cwd(), 'public', 'images');
 
 function getThumbnailCachePath(documentId) {
-  return path.join(THUMBNAIL_CACHE_DIR, `${documentId}.png`);
+  if (documentId == null) {
+    throw new Error('Invalid document ID for thumbnail cache');
+  }
+  const sanitized = String(documentId).replace(/[^a-zA-Z0-9_-]/g, '');
+  if (!sanitized) {
+    throw new Error('Invalid document ID for thumbnail cache');
+  }
+  return path.join(THUMBNAIL_CACHE_DIR, `${sanitized}.png`);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Sanitize `documentId` in `getThumbnailCachePath()` to strip path separators and special characters, preventing directory traversal
- Reject null/undefined/empty IDs with a clear error

Fixes #82

## Test plan

- [x] Normal numeric IDs resolve correctly
- [x] Path traversal attempts (`../../etc/passwd`) stripped to safe filenames
- [x] Null, undefined, empty, dots-only, slashes-only all throw
- [x] Deployed to QA (gpu1) — health check passing, thumbnail endpoint returns 404 (not file leak) for malicious inputs