### PR TITLE
fix: escape < in raw JSON output to prevent script injection

### DIFF
--- a/views/about.ejs
+++ b/views/about.ejs
@@ -138,7 +138,7 @@
         </main>
     </div>
 
-    <script id="supportInfoPayload" type="application/json"><%- JSON.stringify(supportInfo || {}) %></script>
+    <script id="supportInfoPayload" type="application/json"><%- JSON.stringify(supportInfo || {}).replace(/</g, '\\u003c') %></script>
 
     <%- include('partials/scripts/about-scripts') %>
     <%- include('partials/shell/footer') %>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -407,7 +407,7 @@
                 <%= JSON.stringify(paperless_data) %>
             </div>
             <script>
-                window.paperlessPublicUrl = <%- JSON.stringify(typeof paperlessUrl !== 'undefined' ? paperlessUrl : '') %>;
+                window.paperlessPublicUrl = <%- JSON.stringify(typeof paperlessUrl !== 'undefined' ? paperlessUrl : '').replace(/</g, '\\u003c') %>;
             </script>
             <%- include('partials/scripts/dashboard-scripts') %>
                 <script src="js/dashboard.js"></script>

--- a/views/rag.ejs
+++ b/views/rag.ejs
@@ -168,7 +168,7 @@
     </div>
 
     <script>
-        window.paperlessPublicUrl = <%- JSON.stringify(typeof paperlessUrl !== 'undefined' ? paperlessUrl : '') %>;
+        window.paperlessPublicUrl = <%- JSON.stringify(typeof paperlessUrl !== 'undefined' ? paperlessUrl : '').replace(/</g, '\\u003c') %>;
     </script>
     <%- include('partials/scripts/rag-scripts') %>
     <%- include('partials/shell/footer') %>

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -785,7 +785,7 @@
                                 <h3 class="text-lg font-semibold">Runtime Controls</h3>
                                 <div class="space-y-2">
                                     <p class="text-sm text-gray-600">Reset local runtime overrides to fall back to container-managed environment values after restart.</p>
-                                    <button type="button" id="resetLocalOverridesBtn" data-runtime-override-keys="<%- JSON.stringify(runtimeOverrideKeys || []).replace(/\"/g, '&quot;') %>" data-runtime-override-details="<%- JSON.stringify(runtimeOverrideDetails || {}).replace(/\"/g, '&quot;') %>" data-locked-env-keys="<%- JSON.stringify(lockedEnvKeys || []).replace(/\"/g, '&quot;') %>" data-locked-env-details="<%- JSON.stringify(lockedEnvDetails || {}).replace(/\"/g, '&quot;') %>" class="toolbar-btn toolbar-btn--danger flex items-center gap-2">
+                                    <button type="button" id="resetLocalOverridesBtn" data-runtime-override-keys="<%- JSON.stringify(runtimeOverrideKeys || []).replace(/</g, '\\u003c').replace(/\"/g, '&quot;') %>" data-runtime-override-details="<%- JSON.stringify(runtimeOverrideDetails || {}).replace(/</g, '\\u003c').replace(/\"/g, '&quot;') %>" data-locked-env-keys="<%- JSON.stringify(lockedEnvKeys || []).replace(/</g, '\\u003c').replace(/\"/g, '&quot;') %>" data-locked-env-details="<%- JSON.stringify(lockedEnvDetails || {}).replace(/</g, '\\u003c').replace(/\"/g, '&quot;') %>" class="toolbar-btn toolbar-btn--danger flex items-center gap-2">
                                         <i class="fas fa-rotate-left"></i>
                                         <span>Reset Local Overrides (Password Required)</span>
                                     </button>


### PR DESCRIPTION
## Summary

- Add `.replace(/</g, '\\u003c')` to `<%- JSON.stringify(...) %>` in dashboard, rag, about, and settings views
- Prevents `</script>` breakout in inline script blocks and HTML attributes
- Matches the pattern already used in `setup.ejs`

Fixes #87

## Test plan

- [x] Existing `test-ui-xss-hardening.js` passes
- [x] Unit test confirms `</script>` payloads are escaped while normal values round-trip correctly
- [x] Deployed to QA — dashboard loads, health check passing