### PR TITLE
fix: guard JSON.parse of CUSTOM_FIELDS in settings.ejs

### DIFF
--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -637,8 +637,9 @@
                             <section class="space-y-4 settings-section-card">
                                 <h3 class="text-lg font-semibold">Custom Fields</h3>
                                 <div id="customFieldsList" class="space-y-2">
-                                    <% if (config.CUSTOM_FIELDS && Array.isArray(JSON.parse(config.CUSTOM_FIELDS).custom_fields)) { %>
-                                        <% JSON.parse(config.CUSTOM_FIELDS).custom_fields.forEach((field) => { %>
+                                    <% let _parsedCustomFields = []; try { const _cf = JSON.parse(config.CUSTOM_FIELDS || '{}'); if (Array.isArray(_cf.custom_fields)) _parsedCustomFields = _cf.custom_fields; } catch(e) {} %>
+                                    <% if (_parsedCustomFields.length > 0) { %>
+                                        <% _parsedCustomFields.forEach((field) => { %>
                                             <div class="custom-field-item flex items-center gap-2 p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-500 transition-colors">
                                                 <div class="cursor-move text-gray-400"><i class="fas fa-grip-vertical"></i></div>
                                                 <div class="flex-1">


### PR DESCRIPTION
## Summary

- Wrap `JSON.parse(config.CUSTOM_FIELDS)` in settings.ejs in a try-catch
- Invalid, empty, or double-escaped values now degrade gracefully to an empty custom fields list instead of crashing the page with a 500 error

Fixes #84

## Test plan

- [x] Valid JSON with fields renders correctly
- [x] Empty string, null, undefined, garbage, double-escaped JSON all handled without crash
- [x] Deployed to QA — `/settings` returns 200