### PR TITLE
fix: remove redundant CORS middleware, fix German error message, clean up double semicolons

### DIFF
--- a/server.js
+++ b/server.js
@@ -229,7 +229,7 @@ const apiGlobalLimiter = rateLimit({
   max: config.globalRateLimitMax,
   message: {
     success: false,
-    error: 'Zu viele Anfragen. Bitte versuchen Sie es später erneut.'
+    error: 'Too many requests. Please try again later.'
   },
   standardHeaders: true,
   legacyHeaders: false,
@@ -259,15 +259,9 @@ const apiGlobalLimiter = rateLimit({
 
 app.use(cors(corsOptions));
 
+// Chrome Private Network Access: respond to preflight with the required header
 app.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.header('Access-Control-Allow-Headers', 'Content-Type, x-api-key, Access-Control-Allow-Private-Network');
   res.header('Access-Control-Allow-Private-Network', 'true');
-  
-  if (req.method === 'OPTIONS') {
-    return res.status(200).end();
-  }
   next();
 });
 

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -86,7 +86,7 @@ class AzureOpenAIService {
       try {
         customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
       } catch (error) {
-        console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);
         customFieldsObj = { custom_fields: [] };
       }
 
@@ -214,7 +214,7 @@ class AzureOpenAIService {
       try {
         parsedResponse = JSON.parse(jsonContent);
       } catch (error) {
-        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);
         throw new Error('Invalid JSON response from API');
       }
 
@@ -344,7 +344,7 @@ class AzureOpenAIService {
       try {
         parsedResponse = JSON.parse(jsonContent);
       } catch (error) {
-        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);
         throw new Error('Invalid JSON response from API');
       }
 
@@ -402,7 +402,7 @@ class AzureOpenAIService {
 
       return response.choices[0].message.content;
     } catch (error) {
-      console.error(`Error generating text with AzureOpenAI: ${error.message}`); console.debug(error);;
+      console.error(`Error generating text with AzureOpenAI: ${error.message}`); console.debug(error);
       throw error;
     }
   }
@@ -438,7 +438,7 @@ class AzureOpenAIService {
 
       return { status: 'ok', model: model };
     } catch (error) {
-      console.error(`Error generating text with Azure OpenAI: ${error.message}`); console.debug(error);;
+      console.error(`Error generating text with Azure OpenAI: ${error.message}`); console.debug(error);
       return { status: 'error', error: error.message };
     }
   }

--- a/services/customService.js
+++ b/services/customService.js
@@ -86,7 +86,7 @@ class CustomOpenAIService {
       try {
         customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
       } catch (error) {
-        console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);
         customFieldsObj = { custom_fields: [] };
       }
 
@@ -231,7 +231,7 @@ class CustomOpenAIService {
       try {
         parsedResponse = JSON.parse(jsonContent);
       } catch (error) {
-        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);
         throw new Error('Invalid JSON response from API');
       }
 
@@ -362,7 +362,7 @@ class CustomOpenAIService {
       try {
         parsedResponse = JSON.parse(jsonContent);
       } catch (error) {
-        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);
         throw new Error('Invalid JSON response from API');
       }
 
@@ -432,7 +432,7 @@ class CustomOpenAIService {
 
       return response.choices[0].message.content;
     } catch (error) {
-      console.error(`Error generating text with Custom OpenAI: ${error.message}`); console.debug(error);;
+      console.error(`Error generating text with Custom OpenAI: ${error.message}`); console.debug(error);
       throw error;
     }
   }
@@ -452,7 +452,7 @@ class CustomOpenAIService {
 
       return { status: 'ok', model: model };
     } catch (error) {
-      console.error(`Error generating text with Custom OpenAI: ${error.message}`); console.debug(error);;
+      console.error(`Error generating text with Custom OpenAI: ${error.message}`); console.debug(error);
       return { status: 'error', error: error.message };
     }
   }

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -108,7 +108,7 @@ class OllamaService {
                 try {
                     customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
                 } catch (error) {
-                    console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);;
+                    console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);
                     customFieldsObj = { custom_fields: [] };
                 }
 
@@ -249,7 +249,7 @@ class OllamaService {
                 return content.substring(0, process.env.CONTENT_MAX_LENGTH);
             }
         } catch (error) {
-            console.error(`Error truncating content: ${error.message}`); console.debug(error);;
+            console.error(`Error truncating content: ${error.message}`); console.debug(error);
         }
         return content;
     }
@@ -276,7 +276,7 @@ class OllamaService {
         try {
             customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
         } catch (error) {
-            console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);;
+            console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);
             customFieldsObj = { custom_fields: [] };
         }
 
@@ -417,7 +417,7 @@ class OllamaService {
         try {
             customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
         } catch (error) {
-            console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);;
+            console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);
             customFieldsObj = { custom_fields: [] };
         }
 
@@ -737,7 +737,7 @@ class OllamaService {
 
             return response.data.response;
         } catch (error) {
-            console.error(`Error generating text with Ollama: ${error.message}`); console.debug(error);;
+            console.error(`Error generating text with Ollama: ${error.message}`); console.debug(error);
             throw error;
         }
     }

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -94,7 +94,7 @@ class OpenAIService {
       try {
         customFieldsObj = JSON.parse(process.env.CUSTOM_FIELDS);
       } catch (error) {
-        console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse CUSTOM_FIELDS: ${error.message}`); console.debug(error);
         customFieldsObj = { custom_fields: [] };
       }
 
@@ -222,7 +222,7 @@ class OpenAIService {
       try {
         parsedResponse = JSON.parse(jsonContent);
       } catch (error) {
-        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);
         // Check if the response indicates the content is too minimal or API can't process it
         if (jsonContent && (jsonContent.toLowerCase().includes("i'm sorry") ||
             jsonContent.toLowerCase().includes("i cannot") ||
@@ -372,7 +372,7 @@ class OpenAIService {
       try {
         parsedResponse = JSON.parse(jsonContent);
       } catch (error) {
-        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);;
+        console.error(`Failed to parse JSON response: ${error.message}`); console.debug(error);
         // Check if the response indicates the content is too minimal or API can't process it
         if (jsonContent && (jsonContent.toLowerCase().includes("i'm sorry") ||
             jsonContent.toLowerCase().includes("i cannot") ||
@@ -449,7 +449,7 @@ class OpenAIService {
 
       return response.choices[0].message.content;
     } catch (error) {
-      console.error(`Error generating text with OpenAI: ${error.message}`); console.debug(error);;
+      console.error(`Error generating text with OpenAI: ${error.message}`); console.debug(error);
       throw error;
     }
   }
@@ -466,7 +466,7 @@ class OpenAIService {
       await this.client.models.list();
       return { status: 'ok', model: process.env.OPENAI_MODEL };
     } catch (error) {
-      console.error(`Error checking OpenAI status: ${error.message}`); console.debug(error);;
+      console.error(`Error checking OpenAI status: ${error.message}`); console.debug(error);
       return { status: 'error', error: error.message };
     }
   }


### PR DESCRIPTION
## Summary

- Remove manual CORS header middleware that overrode the `cors()` config with a hardcoded wildcard `Access-Control-Allow-Origin: *`; keep only the Private Network Access header which cors() doesn't handle natively
- Replace German rate limit error message with English
- Fix 20 instances of double semicolons (`console.debug(error);;`) across all four AI service files

Fixes #92

## Test plan

- [x] All 18 runnable tests pass
- [x] Deployed to QA — CORS now reflects request origin (not wildcard), Private Network Access header present
- [x] Health check passing