### PR TITLE
fix: clean up retryTracker entry on terminal failure

### DIFF
--- a/server.js
+++ b/server.js
@@ -585,6 +585,7 @@ async function processDocument(doc, existingTags, existingCorrespondentList, exi
   if (docRetries >= 3) {
     console.warn(`Document ${doc.id} has failed ${docRetries} times, skipping to prevent infinite retry loop`);
     await documentModel.setProcessingStatus(doc.id, doc.title, 'failed');
+    retryTracker.delete(doc.id);
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Add missing `retryTracker.delete(doc.id)` when a document exceeds the max retry count (3)
- Matches the cleanup pattern already used in all other terminal failure paths

Fixes #94

## Test plan

- [x] Unit test confirms entries are cleaned on terminal failure
- [x] All 18 runnable tests pass