### PR TITLE
fix: add missing isAuthenticated to key-regenerate and webhook endpoints

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3474,7 +3474,7 @@ async function saveDocumentChanges(docId, updateData, analysis, originalData) {
  *                   type: string
  *                   example: "Error regenerating API key"
  */
-router.post('/api/key-regenerate', async (req, res) => {
+router.post('/api/key-regenerate', isAuthenticated, async (req, res) => {
   try {
     const fs = require('fs');
     const path = require('path');
@@ -5057,7 +5057,7 @@ async function processQueue(customPrompt) {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.post('/api/webhook/document', async (req, res) => {
+router.post('/api/webhook/document', isAuthenticated, async (req, res) => {
   try {
     const { url, prompt } = req.body;
     let usePrompt = false;


### PR DESCRIPTION
## Summary

- Add `isAuthenticated` middleware to `/api/key-regenerate` and `/api/webhook/document`
- Both endpoints were accessible without authentication

Fixes #97

## Test plan

- [x] All 18 runnable tests pass
- [x] Verified both endpoints now return 401 without authentication