### PR TITLE
fix: keep login/setup cards stable on hover

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -58,6 +58,10 @@ main {
     animation: login-card-reveal 360ms ease-out;
 }
 
+.login-card:hover {
+    transform: none;
+}
+
 .login-kicker {
     display: inline-flex;
     align-items: center;

--- a/public/css/setup.css
+++ b/public/css/setup.css
@@ -57,6 +57,10 @@ main {
     animation: setup-card-in 340ms ease-out;
 }
 
+.setup-card:hover {
+    transform: none;
+}
+
 .setup-subtitle {
     color: var(--text-secondary);
     margin-top: 0.35rem;


### PR DESCRIPTION
Fixes #112

The login and setup pages use the shared `material-card` class, which applies `transform: translateY(-2px)` on hover. That makes the whole form jump while hovering.

This keeps those two cards stationary on hover while preserving the existing shadow style.

Greetings, saschabuehrle
