### PR TITLE
fix: handle null correspondents and apply valid correspondent updates

### DIFF
--- a/services/azureService.js
+++ b/services/azureService.js
@@ -229,7 +229,7 @@ class AzureOpenAIService {
         console.warn('Failed to write AI response log:', logError.message);
       }
 
-      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
         throw new Error('AI could not determine assignable metadata: no tags or correspondent found');
       }
 
@@ -356,7 +356,7 @@ class AzureOpenAIService {
       }
 
       // Validate response structure
-      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
         throw new Error('AI could not determine assignable metadata: no tags or correspondent found');
       }
 

--- a/services/customService.js
+++ b/services/customService.js
@@ -247,7 +247,7 @@ class CustomOpenAIService {
       }
 
       // Validate response structure
-      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
         throw new Error('AI could not determine assignable metadata: no tags or correspondent found');
       }
 
@@ -374,7 +374,7 @@ class CustomOpenAIService {
       }
 
       // Validate response structure
-      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
         throw new Error('AI could not determine assignable metadata: no tags or correspondent found');
       }
 

--- a/services/manualService.js
+++ b/services/manualService.js
@@ -90,7 +90,7 @@ class ManualService {
             throw new Error('Invalid JSON response from API');
         }
         
-        if (!Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+        if (!Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
             throw new Error('Invalid response structure');
         }
         
@@ -138,7 +138,7 @@ class ManualService {
             throw new Error('Invalid JSON response from API');
         }
         
-        if (!Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+        if (!Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
             throw new Error('Invalid response structure');
         }
         
@@ -180,7 +180,7 @@ class ManualService {
             
             const parsedResponse = JSON.parse(jsonContent);
             
-            if (!Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+            if (!Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
                 throw new Error('Invalid response structure');
             }
             

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -257,7 +257,7 @@ class OpenAIService {
         console.warn('Failed to write AI response log:', logError.message);
       }
 
-      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
         throw new Error('AI could not determine assignable metadata: no tags or correspondent found');
       }
 
@@ -404,7 +404,7 @@ class OpenAIService {
       }
 
       // Validate response structure
-      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || typeof parsedResponse.correspondent !== 'string') {
+      if (!parsedResponse || !Array.isArray(parsedResponse.tags) || (typeof parsedResponse.correspondent !== 'string' && parsedResponse.correspondent !== null)) {
         throw new Error('AI could not determine assignable metadata: no tags or correspondent found');
       }
 

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -1754,8 +1754,8 @@ async getOrCreateDocumentType(name, options = {}) {
         console.log(`[DEBUG] Combined tags:`, combinedTags);
       }
 
-      if (currentDoc.correspondent && updates.correspondent) {
-        console.log('[DEBUG] Document already has a correspondent, keeping existing one:', currentDoc.correspondent);
+      if (updates.correspondent === null || updates.correspondent === undefined) {
+        // Keep existing correspondent when no new value is provided
         delete updates.correspondent;
       }
 


### PR DESCRIPTION
## Summary
Fix correspondent handling so valid correspondent updates are written to Paperless-ngx and `null` correspondents no longer fail document processing.

## Changes
- allow overwriting an existing correspondent when a new correspondent value is provided
- keep existing correspondent only when update payload has `correspondent: null|undefined`
- accept `correspondent: null` in AI response validation (OpenAI, Azure, Custom, Manual services)

## Why
Issue #120 reports two production problems:
1. valid correspondent selections were ignored when a document already had a correspondent
2. `correspondent: null` caused fatal validation errors and moved docs to failed processing

These changes preserve strict validation while treating `null` as a valid “no correspondent” result.

## Testing
- `node --check services/paperlessService.js`
- `node --check services/openaiService.js`
- `node --check services/customService.js`
- `node --check services/manualService.js`
- `node --check services/azureService.js`

Fixes #120

Greetings, saschabuehrle
