### PR TITLE
RAG Chat Fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -166,9 +166,10 @@ MODEL_CACHE_DIR = "./data/model_cache"
 EMBEDDING_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
 CROSS_ENCODER_MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 COLLECTION_NAME = "documents"
-BM25_WEIGHT = 0.3
-SEMANTIC_WEIGHT = 0.7
+BM25_WEIGHT = float(os.getenv("BM25_WEIGHT", "0.3"))
+SEMANTIC_WEIGHT = float(os.getenv("SEMANTIC_WEIGHT", "0.7"))
 MAX_RESULTS = 20
+RERANK_MAX_CONTENT_CHARS = int(os.getenv("RERANK_MAX_CONTENT_CHARS", "2000"))
 
 # Ensure model cache is persisted across restarts/redeploys
 os.makedirs(MODEL_CACHE_DIR, exist_ok=True)
@@ -1328,27 +1329,34 @@ class SearchEngine:
                 r["score"] = r["score"] / max_keyword_score if max_keyword_score > 0 else 0
         
         if semantic_results:
-            # For semantic search, lower distance is better, so invert the score
+            # For semantic search, lower distance is better, so convert to similarity
+            # First normalize distance to 0-1 range, then invert
+            max_distance = max((r["score"] for r in semantic_results), default=1.0)
+            min_distance = min((r["score"] for r in semantic_results), default=0.0)
+            distance_range = max_distance - min_distance if max_distance != min_distance else 1.0
             for r in semantic_results:
-                # Convert distance to similarity score (1 - normalized_distance)
-                r["score"] = 1 - r["score"] if r["score"] <= 1 else 0
+                # Normalize to 0-1 then invert to get similarity (1 = perfect match)
+                normalized = (r["score"] - min_distance) / distance_range
+                r["score"] = 1 - normalized
         
-        # Add keyword results with weight
+        # Add keyword results with weight (normalize ID to string for consistent merging)
         for result in keyword_results:
-            doc_id = result["id"]
+            doc_id = str(result["id"])
             results_map[doc_id] = {
                 **result,
+                "id": doc_id,
                 "score": result["score"] * BM25_WEIGHT
             }
         
         # Add semantic results with weight
         for result in semantic_results:
-            doc_id = result["id"]
+            doc_id = str(result["id"])
             if doc_id in results_map:
                 results_map[doc_id]["score"] += result["score"] * SEMANTIC_WEIGHT
             else:
                 results_map[doc_id] = {
                     **result,
+                    "id": doc_id,
                     "score": result["score"] * SEMANTIC_WEIGHT
                 }
         
@@ -1367,8 +1375,9 @@ class SearchEngine:
             return []
             
         try:
-            # Prepare pairs for cross-encoder
-            pairs = [(query, f"{result['title']} {result['content'][:500]}" if 'content' in result and result['content'] else result.get('title', '')) 
+            # Prepare pairs for cross-encoder (use more content for better reranking)
+            content_limit = RERANK_MAX_CONTENT_CHARS
+            pairs = [(query, f"{result.get('title', '')} {result.get('content', '')[:content_limit] if result.get('content') else ''}") 
                     for result in results]
             
             # Make sure we have valid pairs
@@ -2061,11 +2070,11 @@ async def initialize_system(force: bool = False, background: bool = True, backgr
         }
     
     # Initialize data manager if needed
-    if not global_state.data_manager.is_initialized:
+    if global_state.data_manager and not global_state.data_manager.is_initialized:
         global_state.data_manager.initialize_models()
     
     # Load documents if needed
-    if not global_state.system_status.data_loaded or force:
+    if global_state.data_manager and (not global_state.system_status.data_loaded or force):
         global_state.data_manager.load_documents(force_refresh=force, check_new=False)
     
     # Initialize search engine

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -5542,6 +5542,9 @@ router.get('/settings', async (req, res) => {
     DISABLE_AUTOMATIC_PROCESSING: process.env.DISABLE_AUTOMATIC_PROCESSING || 'no',
     RAG_SERVICE_ENABLED: process.env.RAG_SERVICE_ENABLED || 'true',
     RAG_SERVICE_URL: process.env.RAG_SERVICE_URL || 'http://localhost:8000',
+    BM25_WEIGHT: process.env.BM25_WEIGHT || '0.3',
+    SEMANTIC_WEIGHT: process.env.SEMANTIC_WEIGHT || '0.7',
+    RERANK_MAX_CONTENT_CHARS: process.env.RERANK_MAX_CONTENT_CHARS || '2000',
     MISTRAL_OCR_ENABLED: process.env.MISTRAL_OCR_ENABLED || 'no',
     MISTRAL_API_KEY: process.env.MISTRAL_API_KEY || '',
     MISTRAL_OCR_MODEL: process.env.MISTRAL_OCR_MODEL || 'mistral-ocr-latest',
@@ -6796,6 +6799,9 @@ router.post('/settings', express.json(), async (req, res) => {
       mistralOcrModel,
       ragServiceEnabled,
       ragServiceUrl,
+      bm25Weight,
+      semanticWeight,
+      rerankMaxContentChars,
       globalRateLimitWindowMs,
       globalRateLimitMax,
       trustProxy,
@@ -7073,6 +7079,9 @@ router.post('/settings', express.json(), async (req, res) => {
       if (mistralOcrModel) updatedConfig.MISTRAL_OCR_MODEL = mistralOcrModel;
       if (ragServiceEnabled) updatedConfig.RAG_SERVICE_ENABLED = ragServiceEnabled;
       if (ragServiceUrl) updatedConfig.RAG_SERVICE_URL = ragServiceUrl;
+      if (bm25Weight) updatedConfig.BM25_WEIGHT = bm25Weight;
+      if (semanticWeight) updatedConfig.SEMANTIC_WEIGHT = semanticWeight;
+      if (rerankMaxContentChars) updatedConfig.RERANK_MAX_CONTENT_CHARS = rerankMaxContentChars;
       if (globalRateLimitWindowMs) updatedConfig.GLOBAL_RATE_LIMIT_WINDOW_MS = globalRateLimitWindowMs;
       if (globalRateLimitMax) updatedConfig.GLOBAL_RATE_LIMIT_MAX = globalRateLimitMax;
       if (typeof trustProxy === 'string') updatedConfig.TRUST_PROXY = trustProxy.trim();

--- a/services/ragService.js
+++ b/services/ragService.js
@@ -4,6 +4,8 @@ const config = require('../config/config');
 const AIServiceFactory = require('./aiServiceFactory');
 const paperlessService = require('./paperlessService');
 
+const DEFAULT_TIMEOUT = 30000;
+
 class RagService {
   constructor() {
     this.baseUrl = process.env.RAG_SERVICE_URL || 'http://localhost:8000';
@@ -12,14 +14,18 @@ class RagService {
     this.aiStatusTtlMs = Number(process.env.RAG_AI_STATUS_TTL_MS || 300000);
   }
 
+  async _getClient() {
+    return axios.create({ timeout: DEFAULT_TIMEOUT });
+  }
+
   /**
    * Check if the RAG service is available and ready
    * @returns {Promise<{status: string, index_ready: boolean, data_loaded: boolean}>}
    */
   async checkStatus() {
     try {
-      const response = await axios.get(`${this.baseUrl}/status`);
-      //make test call to the LLM service to check if it is available
+      const client = await this._getClient();
+      const response = await client.get(`${this.baseUrl}/status`);
       return response.data;
     } catch (error) {
       console.error('Error checking RAG service status:', error.message);
@@ -40,7 +46,8 @@ class RagService {
    */
   async search(query, filters = {}) {
     try {
-      const response = await axios.post(`${this.baseUrl}/search`, {
+      const client = await this._getClient();
+      const response = await client.post(`${this.baseUrl}/search`, {
         query,
         ...filters
       });
@@ -58,16 +65,22 @@ class RagService {
    */
   async askQuestion(question) {
     try {
+      const client = await this._getClient();
       // 1. Get context from the RAG service
-      const response = await axios.post(`${this.baseUrl}/context`, { 
+      const response = await client.post(`${this.baseUrl}/context`, { 
         question,
         max_sources: 5
       });
       
-      const { context, sources } = response.data;
+      const { context, sources: originalSources } = response.data;
       
       // 2. Fetch full content for each source document using doc_id
       let enhancedContext = context;
+      let sources = originalSources;
+      const failedDocIds = [];
+      const MAX_CONTEXT_TOKENS = 8000;
+      const CHARS_PER_TOKEN = 4;
+      const maxContextChars = MAX_CONTEXT_TOKENS * CHARS_PER_TOKEN;
       
       if (sources && sources.length > 0) {
         // Fetch full document content for each source
@@ -76,18 +89,48 @@ class RagService {
             if (source.doc_id) {
               try {
                 const fullContent = await paperlessService.getDocumentContent(source.doc_id);
-                return `Full document content for ${source.title || 'Document ' + source.doc_id}:\n${fullContent}`;
+                return { docId: source.doc_id, title: source.title, content: fullContent, success: true };
               } catch (error) {
                 console.error(`Error fetching content for document ${source.doc_id}:`, error.message);
-                return '';
+                failedDocIds.push(source.doc_id);
+                return { docId: source.doc_id, title: source.title, content: null, success: false };
               }
             }
-            return '';
+            return null;
           })
         );
         
-        // Combine original context with full document contents
-        enhancedContext = context + '\n\n' + fullDocContents.filter(content => content).join('\n\n');
+        // Build enhanced context with token limit
+        let totalChars = context.length;
+        const includedDocs = [];
+        
+        for (const doc of fullDocContents) {
+          if (!doc || !doc.content) continue;
+          
+          const docText = `Full document content for ${doc.title || 'Document ' + doc.docId}:\n${doc.content}`;
+          
+          // Check if adding this document would exceed the limit
+          if (totalChars + docText.length > maxContextChars) {
+            // Try to fit a truncated version
+            const remainingChars = maxContextChars - totalChars - 50; // 50 for the wrapper text
+            if (remainingChars > 500) {
+              const truncatedText = `Full document content for ${doc.title || 'Document ' + doc.docId}:\n${doc.content.substring(0, remainingChars)}...\n[truncated]`;
+              includedDocs.push(truncatedText);
+              totalChars += truncatedText.length;
+            }
+            break; // No more docs can fit
+          }
+          
+          includedDocs.push(docText);
+          totalChars += docText.length;
+        }
+        
+        if (includedDocs.length > 0) {
+          enhancedContext = context + '\n\n' + includedDocs.join('\n\n');
+        }
+        
+        // Update sources to only include successfully fetched docs
+        sources = sources.filter(s => !failedDocIds.includes(s.doc_id));
       }
       
       // 3. Use AI service to generate an answer based on the enhanced context
@@ -137,7 +180,8 @@ class RagService {
    */
   async indexDocuments(force = false) {
     try {
-      const response = await axios.post(`${this.baseUrl}/indexing/start`, { 
+      const client = await this._getClient();
+      const response = await client.post(`${this.baseUrl}/indexing/start`, { 
         force, 
         background: true 
       });
@@ -154,7 +198,8 @@ class RagService {
    */
   async checkForUpdates() {
     try {
-      const response = await axios.post(`${this.baseUrl}/indexing/check`);
+      const client = await this._getClient();
+      const response = await client.post(`${this.baseUrl}/indexing/check`);
       return response.data;
     } catch (error) {
       console.error('Error checking for updates:', error);
@@ -168,7 +213,8 @@ class RagService {
    */
   async getIndexingStatus() {
     try {
-      const response = await axios.get(`${this.baseUrl}/indexing/status`);
+      const client = await this._getClient();
+      const response = await client.get(`${this.baseUrl}/indexing/status`);
       return response.data;
     } catch (error) {
       console.error('Error getting indexing status:', error);
@@ -183,7 +229,8 @@ class RagService {
    */
   async initialize(force = false) {
     try {
-      const response = await axios.post(`${this.baseUrl}/initialize`, { force });
+      const client = await this._getClient();
+      const response = await client.post(`${this.baseUrl}/initialize`, { force });
       return response.data;
     } catch (error) {
       console.error('Error initializing RAG service:', error);
@@ -197,7 +244,8 @@ class RagService {
    */
   async redownloadModels() {
     try {
-      const response = await axios.post(`${this.baseUrl}/models/redownload`, {
+      const client = await this._getClient();
+      const response = await client.post(`${this.baseUrl}/models/redownload`, {
         background: true
       });
       return response.data;
@@ -216,7 +264,8 @@ class RagService {
     const { reason = 'config_save', delaySeconds = 0.75 } = options;
 
     try {
-      const response = await axios.post(
+      const client = await this._getClient();
+      const response = await client.post(
         `${this.baseUrl}/system/restart`,
         {
           reason,

--- a/services/ragService.js
+++ b/services/ragService.js
@@ -14,7 +14,7 @@ class RagService {
     this.aiStatusTtlMs = Number(process.env.RAG_AI_STATUS_TTL_MS || 300000);
   }
 
-  async _getClient() {
+  _getClient() {
     return axios.create({ timeout: DEFAULT_TIMEOUT });
   }
 

--- a/views/partials/scripts/rag-scripts.ejs
+++ b/views/partials/scripts/rag-scripts.ejs
@@ -233,11 +233,13 @@
         if (indexingRunning) return;
 
         initializeRequested = true;
+        const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
         try {
             await fetch('/api/rag/initialize', {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': csrfToken || ''
                 },
                 body: JSON.stringify({ force: false })
             });

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -770,6 +770,24 @@
                                     </div>
                                 </div>
 
+                                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    <div class="space-y-2">
+                                        <label for="bm25Weight" class="text-sm font-medium">BM25 Weight (0-1)</label>
+                                        <input type="number" id="bm25Weight" name="bm25Weight" min="0" max="1" step="0.1" value="<%= config.BM25_WEIGHT || 0.3 %>" class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                        <p class="text-xs text-gray-500">ENV: BM25_WEIGHT · Restart required</p>
+                                    </div>
+                                    <div class="space-y-2">
+                                        <label for="semanticWeight" class="text-sm font-medium">Semantic Weight (0-1)</label>
+                                        <input type="number" id="semanticWeight" name="semanticWeight" min="0" max="1" step="0.1" value="<%= config.SEMANTIC_WEIGHT || 0.7 %>" class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                        <p class="text-xs text-gray-500">ENV: SEMANTIC_WEIGHT · Restart required</p>
+                                    </div>
+                                    <div class="space-y-2">
+                                        <label for="rerankMaxContentChars" class="text-sm font-medium">Rerank Max Content (chars)</label>
+                                        <input type="number" id="rerankMaxContentChars" name="rerankMaxContentChars" min="500" max="10000" step="100" value="<%= config.RERANK_MAX_CONTENT_CHARS || 2000 %>" class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                        <p class="text-xs text-gray-500">ENV: RERANK_MAX_CONTENT_CHARS · Restart required</p>
+                                    </div>
+                                </div>
+
                                 <% if (ragEnabled) { %>
                                 <div class="space-y-2">
                                     <p class="text-sm text-gray-600">Force clear the local RAG model cache and re-download all embedding/reranking models in the background.</p>


### PR DESCRIPTION
Hey there!

I fixed a few things that stood out to me while using the rag chat feature of paperless-ai-next.

## Main Changes
- Fixed a bug in score normalization: The semantic search returns distance, not similarity. But the 1 - distance conversion assumes normalized distance (0-1). If ChromaDB returns raw cosine distance, results got clamped to 0 incorrectly
- Fixed unbounded context concatenation: Large documents or many sources could exceed model context windows, which could have caused truncation or errors
- Cross encoder only saw title and first 500 chars, which could have lead to a suboptimal reranking if content later in the document is of interest
- Made hardcoded weights configurable from the UI