### PR TITLE
fix: map Ollama token metrics from API response

### DIFF
--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -165,12 +165,14 @@ class OllamaService {
             await this._logPromptAndResponse(prompt, parsedResponse);
 
             // Return results in consistent format
+            const promptTokens = response.prompt_eval_count || 0;
+            const completionTokens = response.eval_count || 0;
             return {
                 document: parsedResponse,
                 metrics: {
-                    promptTokens: 0,  // Ollama doesn't provide token metrics
-                    completionTokens: 0,
-                    totalTokens: 0
+                    promptTokens,
+                    completionTokens,
+                    totalTokens: promptTokens + completionTokens
                 },
                 truncated: false
             };
@@ -218,12 +220,14 @@ class OllamaService {
             }
 
             // Return results in consistent format
+            const promptTokens = response.prompt_eval_count || 0;
+            const completionTokens = response.eval_count || 0;
             return {
                 document: parsedResponse,
                 metrics: {
-                    promptTokens: 0,
-                    completionTokens: 0,
-                    totalTokens: 0
+                    promptTokens,
+                    completionTokens,
+                    totalTokens: promptTokens + completionTokens
                 },
                 truncated: false
             };


### PR DESCRIPTION
> **Disclosure:** This fix was developed and tested with AI assistance (Claude Code). Happy to close this if that's not welcome — no hard feelings at all.

Fixes #147

## Summary

- Map Ollama's `prompt_eval_count` → `promptTokens` and `eval_count` → `completionTokens` in `ollamaService.js`
- Applies to both `analyzeDocument()` and `analyzePlayground()`
- Uses `|| 0` fallback so it's safe if the fields are ever absent

## Background

Ollama's `/api/generate` response includes token counts under different field names than OpenAI. They were being ignored and hardcoded to `0`. After this fix, the dashboard AI Statistics, Token Trend, and per-document History metrics all populate correctly for Ollama users.

## Test plan

- [x] Verified on live deployment with `qwen2.5:7b-instruct-q4_K_M`
- [x] Metrics record real values (e.g., `prompt=4913, completion=84, total=4997`)
- [x] Dashboard stats populate correctly
- [x] No impact on OpenAI/Azure/Custom providers (separate service files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)