### PR TITLE
Fix Ollama service temperature settings and add tests

### DIFF
--- a/config/changelog.js
+++ b/config/changelog.js
@@ -8,4 +8,8 @@ module.exports = {
     'New: What\'s New modal shows release highlights after each update',
     'Removed RAG features to focus on core document management capabilities <a href="https://github.com/admonstrator/paperless-ai-next/discussions/144">(see here)</a>',
   ],
+  version: 'v2026.05.02',
+  entries: [
+    'Fix: Fixed hardcoded temperature settings for Ollama API',
+  ]
 };

--- a/config/config.js
+++ b/config/config.js
@@ -281,7 +281,7 @@ startupLog(logLevel, 'info', 'Configuration loaded:', {
 });
 
 module.exports = {
-  PAPERLESS_AI_VERSION: 'v2026.05.01',
+  PAPERLESS_AI_VERSION: 'v2026.05.02',
   CONFIGURED: false,
   configSourceMode: CONFIG_SOURCE_MODE,
   getApiKey,

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -43,6 +43,7 @@ const TESTS = {
   'ocr-fallback-ai-errors': 'test-ocr-fallback-ai-errors.js',
   'ocr-startup-recovery': 'test-ocr-startup-recovery.js',
   'pr772-fix': 'test-pr772-fix.js',
+  'ollama-temperature-wiring': 'test-ollama-temperature-wiring.js',
   'rate-limiting': 'test-rate-limiting.js',
   'scan-stop-flow': 'test-scan-stop-flow.js',
   'setup-auth-endpoint-protection': 'test-setup-auth-endpoint-protection.js',
@@ -69,6 +70,7 @@ const AREAS = {
     'effective-document-count-cache',
     'failed-reset-all',
     'injected-env-priority',
+    'ollama-temperature-wiring',
     'pr772-fix',
     'scan-stop-flow',
     'thumbnail-startup-migration'

--- a/services/ollamaService.js
+++ b/services/ollamaService.js
@@ -578,7 +578,7 @@ class OllamaService {
             stream: false,
             format: schema,
             options: {
-                temperature: 0.7,
+                temperature: config.aiTemperatureAnalysis,
                 top_p: 0.9,
                 repeat_penalty: 1.1,
                 top_k: 7,
@@ -736,7 +736,7 @@ class OllamaService {
                 system: systemPrompt,
                 stream: false,
                 options: {
-                    temperature: 0.7,
+                    temperature: config.aiTemperatureGeneration,
                     top_p: 0.9,
                     num_predict: 1024,
                     num_ctx: numCtx

--- a/tests/test-ollama-temperature-wiring.js
+++ b/tests/test-ollama-temperature-wiring.js
@@ -1,0 +1,102 @@
+const assert = require('assert');
+
+const configModulePath = require.resolve('../config/config');
+const ollamaServiceModulePath = require.resolve('../services/ollamaService');
+const axiosModulePath = require.resolve('axios');
+
+const originalEnv = { ...process.env };
+const originalAxiosExport = require.cache[axiosModulePath]?.exports;
+
+function restoreEnvironment() {
+  process.env = originalEnv;
+  delete require.cache[configModulePath];
+  delete require.cache[ollamaServiceModulePath];
+  delete require.cache[axiosModulePath];
+
+  if (typeof originalAxiosExport !== 'undefined') {
+    require.cache[axiosModulePath] = {
+      id: axiosModulePath,
+      filename: axiosModulePath,
+      loaded: true,
+      exports: originalAxiosExport
+    };
+  }
+}
+
+function loadOllamaServiceWithAxiosMock(axiosMock) {
+  delete require.cache[configModulePath];
+  delete require.cache[ollamaServiceModulePath];
+  delete require.cache[axiosModulePath];
+
+  require.cache[axiosModulePath] = {
+    id: axiosModulePath,
+    filename: axiosModulePath,
+    loaded: true,
+    exports: axiosMock
+  };
+
+  return require('../services/ollamaService');
+}
+
+async function main() {
+  const capturedRequests = [];
+
+  const axiosMock = {
+    create() {
+      return {
+        post: async (_url, requestBody) => {
+          capturedRequests.push(requestBody);
+
+          return {
+            data: {
+              response: {
+                tags: [],
+                correspondent: null,
+                title: '',
+                document_date: '',
+                document_type: '',
+                language: ''
+              }
+            }
+          };
+        }
+      };
+    }
+  };
+
+  try {
+    process.env.AI_TEMPERATURE_ANALYSIS = '0.2';
+    process.env.AI_TEMPERATURE_GENERATION = '1.1';
+
+    const ollamaService = loadOllamaServiceWithAxiosMock(axiosMock);
+
+    await ollamaService._callOllamaAPI('prompt', 'system', 512, { type: 'object' });
+
+    ollamaService._calculatePromptTokenCount = () => 12;
+    ollamaService._calculateNumCtx = () => 1024;
+    await ollamaService.generateText('hello');
+
+    assert.strictEqual(capturedRequests.length, 2, 'Expected two outgoing Ollama requests');
+    assert.strictEqual(
+      capturedRequests[0].options.temperature,
+      0.2,
+      'Expected analysis request temperature to use AI_TEMPERATURE_ANALYSIS'
+    );
+    assert.strictEqual(
+      capturedRequests[1].options.temperature,
+      1.1,
+      'Expected generation request temperature to use AI_TEMPERATURE_GENERATION'
+    );
+  } finally {
+    restoreEnvironment();
+  }
+}
+
+main()
+  .then(() => {
+    console.log('[PASS] Ollama temperature wiring uses configured analysis and generation values');
+  })
+  .catch((error) => {
+    console.error('[FAIL] Ollama temperature wiring test failed:', error.message);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
This pull request updates the Ollama API integration to use configurable temperature settings for analysis and generation, instead of hardcoded values. It also adds automated testing to ensure the correct wiring of these settings, and bumps the application version to reflect these changes.

**Ollama API temperature configuration:**

* Updated `OllamaService` to use `config.aiTemperatureAnalysis` and `config.aiTemperatureGeneration` for the `temperature` parameter in API requests, replacing hardcoded values. [[1]](diffhunk://#diff-d6804daa8d57e38db577a5de2b087fe2306cca6069e2c4eedabb93e1559600c3L581-R581) [[2]](diffhunk://#diff-d6804daa8d57e38db577a5de2b087fe2306cca6069e2c4eedabb93e1559600c3L739-R739)

**Testing and validation:**

* Added a new test file `tests/test-ollama-temperature-wiring.js` to verify that the correct temperature values are used in Ollama API requests based on configuration.
* Registered the new test in the test runner by updating `scripts/run-tests.js` (`TESTS` and `AREAS` constants). [[1]](diffhunk://#diff-67a9077c31d626e4f2d1e1db9b51772f6f7f93f95041b1e782a2900b8837787cR46) [[2]](diffhunk://#diff-67a9077c31d626e4f2d1e1db9b51772f6f7f93f95041b1e782a2900b8837787cR73)

**Versioning and changelog:**

* Updated the application version to `v2026.05.02` in `config/config.js` and documented the fix in the changelog. [[1]](diffhunk://#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bL284-R284) [[2]](diffhunk://#diff-3f3c4154728b4b66c0407bbb3822aeee1942bb33b601a04b03bd5e0f1fcbf25fR11-R14)

Fixes #177 