### PR TITLE
Enhance document reprocessing and logging for better user experience

### DIFF
--- a/OPENAPI/openapi.json
+++ b/OPENAPI/openapi.json
@@ -1724,6 +1724,88 @@
         }
       }
     },
+    "/api/history/rescan": {
+      "post": {
+        "summary": "Rescan (reprocess) multiple documents by ID",
+        "description": "Forces reprocessing of the given documents regardless of the configured\nscan tag filters. The local processing record is cleared and each document\nis enqueued for direct AI processing, bypassing PROCESS_PREDEFINED_DOCUMENTS\n/ TAGS scan-scope rules. Processing runs in the background.\n",
+        "tags": [
+          "History"
+        ],
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "apiKey": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "ids"
+                ],
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "description": "Document IDs to reprocess",
+                    "example": [
+                      42,
+                      43,
+                      44
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Documents enqueued for reprocessing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "queued": {
+                      "type": "integer",
+                      "example": 3
+                    },
+                    "notFound": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      },
+                      "example": []
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document IDs"
+          },
+          "401": {
+            "description": "Authentication required"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/api/settings/clear-tag-cache": {
       "post": {
         "summary": "Manually clear the centralized tag cache",

--- a/models/document.js
+++ b/models/document.js
@@ -254,6 +254,23 @@ const MIGRATIONS = [
         database.exec('ALTER TABLE users ADD COLUMN last_seen_changelog_version TEXT DEFAULT NULL');
       }
     }
+  },
+  {
+    version: 7,
+    description: 'Deduplicate history_documents and enforce one entry per document_id',
+    up: (database) => {
+      // Remove duplicate history rows that accumulated because addToHistory()
+      // used a plain INSERT with no uniqueness on document_id. Keep only the
+      // newest row (highest id) per document_id; no document is lost.
+      database.exec(`
+        DELETE FROM history_documents
+        WHERE id NOT IN (
+          SELECT MAX(id) FROM history_documents GROUP BY document_id
+        )
+      `);
+      // Prevent future duplicates and enable the UPSERT in addToHistory().
+      database.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_history_documents_document_id ON history_documents(document_id)');
+    }
   }
 ];
 
@@ -399,6 +416,13 @@ module.exports = {
       const result = db.prepare(`
         INSERT INTO history_documents (document_id, tags, title, correspondent, custom_fields, document_type_name, language)
         VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(document_id) DO UPDATE SET
+          tags = excluded.tags,
+          title = excluded.title,
+          correspondent = excluded.correspondent,
+          custom_fields = excluded.custom_fields,
+          document_type_name = excluded.document_type_name,
+          language = excluded.language
       `).run(documentId, tagIdsString, title, correspondent, customFieldsString, documentTypeName ?? null, language ?? null);
       if (result.changes > 0) {
         console.log(`[DEBUG] Document ${title} added to history`);

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -798,14 +798,20 @@ class HistoryManager {
         }
 
         try {
-            // 1. Clear local processing records so the documents are eligible again.
-            const ok = await this.resetDocuments(ids);
-            if (!ok) return;
+            // Reprocess the selected documents directly, bypassing the scan tag
+            // filter (the backend clears their local record and enqueues them).
+            const response = await fetch('/api/history/rescan', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ids })
+            });
+            if (!response.ok) throw new Error('Rescan request failed');
 
-            // 2. Trigger an immediate scan (fire and forget).
-            fetch('/api/scan/now', { method: 'POST' }).catch(() => {});
-
+            await this.table.ajax.reload();
             this.showToast(`${ids.length} document(s) sent for rescan. It might take a few moments to process.`, 'success');
+        } catch (err) {
+            console.error('Bulk rescan failed:', err);
+            this.showToast('Rescan failed. Please try again.', 'error');
         } finally {
             if (btn) {
                 btn.disabled  = false;
@@ -823,21 +829,19 @@ class HistoryManager {
         }
 
         try {
-            // 1. Reset document in DB
+            // Reprocess directly, bypassing the scan tag filter. The backend
+            // clears the local record and enqueues the document for processing.
             const resetRes = await fetch(`/api/history/${documentId}/rescan`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' }
             });
             if (!resetRes.ok) throw new Error('Reset failed');
 
-            // 2. Trigger immediate scan (fire and forget)
-            fetch('/api/scan/now', { method: 'POST' }).catch(() => {});
-
-            // 3. Close modal & show toast
+            // Close modal & show toast
             this.hideModal(document.getElementById('infoModal'));
             this.showToast('Document sent for rescan. It might take a few moments to process.', 'success');
 
-            // 4. Reload table
+            // Reload table
             this.table?.ajax.reload();
         } catch (err) {
             console.error('Rescan failed:', err);

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -367,6 +367,9 @@ class HistoryManager {
         document.getElementById('resetAllBtn')?.addEventListener('click', () => {
             this.showModal(this.confirmModalAll);
         });
+
+        // Rescan Selected button
+        document.getElementById('rescanSelectedBtn')?.addEventListener('click', () => this._handleRescanSelected());
     }
 
     initializeFilters() {
@@ -772,6 +775,37 @@ class HistoryManager {
         } catch (err) {
             console.error('Restore failed:', err);
             this.showToast('Restore failed: ' + err.message, 'error');
+        } finally {
+            if (btn) {
+                btn.disabled  = false;
+                btn.innerHTML = origHtml;
+            }
+        }
+    }
+
+    async _handleRescanSelected() {
+        const ids = this.getSelectedDocuments();
+        if (ids.length === 0) {
+            this.showToast('Please select at least one document to rescan.', 'error');
+            return;
+        }
+
+        const btn = document.getElementById('rescanSelectedBtn');
+        const origHtml = btn?.innerHTML;
+        if (btn) {
+            btn.disabled  = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Rescanning...';
+        }
+
+        try {
+            // 1. Clear local processing records so the documents are eligible again.
+            const ok = await this.resetDocuments(ids);
+            if (!ok) return;
+
+            // 2. Trigger an immediate scan (fire and forget).
+            fetch('/api/scan/now', { method: 'POST' }).catch(() => {});
+
+            this.showToast(`${ids.length} document(s) sent for rescan. It might take a few moments to process.`, 'success');
         } finally {
             if (btn) {
                 btn.disabled  = false;

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -2064,15 +2064,86 @@ router.post('/api/history/:id/rescan', isAuthenticated, async (req, res) => {
       return res.status(400).json({ success: false, error: 'Invalid document ID' });
     }
 
-    await documentModel.deleteDocumentsIdList([documentId]);
+    await rescanDocumentsByIds([documentId]);
 
     res.json({
       success: true,
-      message: 'Dokument wurde zurückgesetzt und wird beim nächsten Scan erneut verarbeitet.'
+      message: 'Document queued for reprocessing.'
     });
   } catch (error) {
     console.error('[ERROR] /api/history/:id/rescan:', error);
     res.status(500).json({ success: false, error: 'Internal server error' });
+  }
+});
+
+/**
+ * @swagger
+ * /api/history/rescan:
+ *   post:
+ *     summary: Rescan (reprocess) multiple documents by ID
+ *     description: |
+ *       Forces reprocessing of the given documents regardless of the configured
+ *       scan tag filters. The local processing record is cleared and each document
+ *       is enqueued for direct AI processing, bypassing PROCESS_PREDEFINED_DOCUMENTS
+ *       / TAGS scan-scope rules. Processing runs in the background.
+ *     tags:
+ *       - History
+ *     security:
+ *       - cookieAuth: []
+ *       - apiKey: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - ids
+ *             properties:
+ *               ids:
+ *                 type: array
+ *                 items:
+ *                   type: integer
+ *                 description: Document IDs to reprocess
+ *                 example: [42, 43, 44]
+ *     responses:
+ *       200:
+ *         description: Documents enqueued for reprocessing
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 queued:
+ *                   type: integer
+ *                   example: 3
+ *                 notFound:
+ *                   type: array
+ *                   items:
+ *                     type: integer
+ *                   example: []
+ *       400:
+ *         description: Invalid document IDs
+ *       401:
+ *         description: Authentication required
+ *       500:
+ *         description: Server error
+ */
+router.post('/api/history/rescan', isAuthenticated, async (req, res) => {
+  try {
+    const { ids } = req.body;
+    if (!ids || !Array.isArray(ids) || ids.length === 0) {
+      return res.status(400).json({ success: false, error: 'Invalid document IDs' });
+    }
+
+    const { queued, notFound } = await rescanDocumentsByIds(ids);
+    res.json({ success: true, queued, notFound });
+  } catch (error) {
+    console.error('[ERROR] /api/history/rescan:', error);
+    res.status(500).json({ success: false, error: 'Error queuing documents for rescan' });
   }
 });
 
@@ -4936,11 +5007,63 @@ async function processQueue(customPrompt) {
     console.error('[ERROR] Error during queue processing:', error);
   } finally {
     isProcessing = false;
-    
+
     if (documentQueue.length > 0) {
       processQueue();
     }
   }
+}
+
+/**
+ * Reprocess specific documents by ID, bypassing the scan tag/filter rules.
+ *
+ * Clears the local processed_documents record (so the processDocument() gate
+ * lets them through) and enqueues each document for direct AI processing via
+ * the shared documentQueue — regardless of whether it still carries the
+ * configured trigger tag. Processing runs in the background (fire-and-forget)
+ * so callers get a fast response.
+ *
+ * @param {Array<number|string>} ids - Document IDs to reprocess.
+ * @returns {Promise<{queued: number, notFound: number[]}>}
+ */
+async function rescanDocumentsByIds(ids) {
+  const numericIds = (Array.isArray(ids) ? ids : [])
+    .map((id) => parseInt(id, 10))
+    .filter((id) => Number.isInteger(id) && id > 0);
+
+  if (numericIds.length === 0) {
+    return { queued: 0, notFound: [] };
+  }
+
+  // Drop the local "already processed" record so the gate in processDocument()
+  // no longer skips these documents.
+  await documentModel.deleteDocumentsIdList(numericIds);
+  await removeThumbnailCacheForDocumentIds(numericIds);
+
+  const notFound = [];
+  let queued = 0;
+
+  for (const id of numericIds) {
+    try {
+      const document = await paperlessService.getDocument(id);
+      if (!document) {
+        notFound.push(id);
+        continue;
+      }
+      documentQueue.push(document);
+      queued += 1;
+    } catch (error) {
+      console.error(`[ERROR] Failed to fetch document ${id} for rescan:`, error.message);
+      notFound.push(id);
+    }
+  }
+
+  // Fire-and-forget: the HTTP response should not wait for AI processing.
+  if (queued > 0) {
+    processQueue();
+  }
+
+  return { queued, notFound };
 }
 
 /**

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -2778,7 +2778,10 @@ router.post('/api/scan/stop', isAuthenticated, async (req, res) => {
 
 async function processDocument(doc, existingTags, existingCorrespondentList, existingDocumentTypesList, ownUserId, customPrompt = null) {
   const isProcessed = await documentModel.isDocumentProcessed(doc.id);
-  if (isProcessed) return null;
+  if (isProcessed) {
+    console.log(`[DEBUG] Document ${doc.id} already in processed_documents — skipping. Remove via Rescan to reprocess.`);
+    return null;
+  }
 
   const isFailed = await documentModel.isDocumentFailed(doc.id);
   if (isFailed) {

--- a/server.js
+++ b/server.js
@@ -51,6 +51,11 @@ const txtLogger = new Logger({
 });
 
 const app = express();
+// Express 5 changed the default query parser to "simple", which does not parse
+// nested bracket parameters (e.g. order[0][column], columns[1][data]) sent by
+// DataTables server-side processing. Restore the Express 4 "extended" (qs)
+// parser so req.query.order/columns are objects again and table sorting works.
+app.set('query parser', 'extended');
 const scanControl = global.__paperlessAiScanControl || {
   running: false,
   stopRequested: false,

--- a/views/history.ejs
+++ b/views/history.ejs
@@ -22,6 +22,9 @@
                         <button id="deselectAllDocsBtn" class="toolbar-btn toolbar-btn--neutral toolbar-btn--sm" title="Deselect all visible documents">
                             <i class="fas fa-square"></i> Deselect All
                         </button>
+                        <button id="rescanSelectedBtn" class="toolbar-btn toolbar-btn--warning toolbar-btn--sm" title="Reprocess selected documents (clears local processing record and triggers a scan)">
+                            <i class="fas fa-rotate-right"></i> Rescan Selected
+                        </button>
                         <button id="forceReloadBtn" class="toolbar-btn toolbar-btn--primary toolbar-btn--sm" title="Force reload filters (bypass cache)">
                             <i class="fas fa-sync-alt"></i> Force Reload
                         </button>


### PR DESCRIPTION
Improves the document reprocessing functionality by adding a "Rescan Selected" bulk action, which allows users to reprocess documents directly from the UI, bypassing the scan tag filters. This addresses the issue where documents with removed `ai-processed` tags were silently skipped during scans. Additionally, it introduces logging for skipped documents to enhance diagnostics. The history management now prevents duplicate entries and restores sorting functionality in the history table.

Fixes #202