### PR TITLE
feat: make OCR document-processing timeout configurable (#196)

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -4344,7 +4344,8 @@ router.post('/api/setup/complete', express.json(), async (req, res) => {
     const setupValidationTimeoutMs = setupService.normalizeValidationTimeoutMs(req.body?.setupValidationTimeoutMs, 30000);
     const setupOcrValidationTimeoutMs = setupService.normalizeValidationTimeoutMs(
       req.body?.setupOcrValidationTimeoutMs ?? req.body?.setupValidationTimeoutMs,
-      30000
+      30000,
+      600000 // OCR processing may run up to 10 min; the check itself stays capped at 120s
     );
 
     const allowFailedPaperlessTest = parseBooleanInput(req.body?.allowFailedPaperlessTest, false);
@@ -6967,7 +6968,8 @@ router.post('/settings', express.json(), async (req, res) => {
       : String(currentConfig.MISTRAL_OCR_MODEL || 'mistral-ocr-latest').trim();
     const effectiveOcrValidationTimeoutMs = setupService.normalizeValidationTimeoutMs(
       hasValue(ocrValidationTimeout) ? Number.parseInt(String(ocrValidationTimeout).trim(), 10) * 1000 : currentConfig.SETUP_OCR_VALIDATION_TIMEOUT_MS,
-      30000
+      30000,
+      600000 // OCR processing may run up to 10 min; the check itself stays capped at 120s
     );
     const normalizeCompare = (value) => String(value || '').trim();
 

--- a/services/mistralOcrService.js
+++ b/services/mistralOcrService.js
@@ -13,6 +13,25 @@ const documentModel = require('../models/document');
 const AIServiceFactory = require('./aiServiceFactory');
 const { isTimeoutError, buildTimeoutErrorMessage } = require('./serviceUtils');
 
+// OCR document processing can take far longer than the connection check —
+// large documents on slow local models routinely exceed the old hard 2-minute
+// limit. Reuse the configured OCR connection-check timeout value
+// (SETUP_OCR_VALIDATION_TIMEOUT_MS, falling back to SETUP_VALIDATION_TIMEOUT_MS),
+// but apply a separate, higher cap here: the connection check stays capped at
+// 120s in setupService, while processing may run up to 10 minutes. Falls back
+// to the previous 120s default when no value is configured.
+const OCR_PROCESSING_TIMEOUT_DEFAULT_MS = 120000;
+const OCR_PROCESSING_TIMEOUT_MAX_MS = 600000;
+
+function getOcrProcessingTimeoutMs() {
+  const raw = process.env.SETUP_OCR_VALIDATION_TIMEOUT_MS || process.env.SETUP_VALIDATION_TIMEOUT_MS;
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isFinite(parsed)) {
+    return OCR_PROCESSING_TIMEOUT_DEFAULT_MS;
+  }
+  return Math.min(Math.max(parsed, 1000), OCR_PROCESSING_TIMEOUT_MAX_MS);
+}
+
 class MistralOcrService {
   constructor() {
     this.activeDocumentIds = new Set();
@@ -137,12 +156,12 @@ class MistralOcrService {
             'Authorization': `Bearer ${this.apiKey}`,
             'Content-Type': 'application/json'
           },
-          timeout: 120000 // 2 minute timeout for large documents
+          timeout: getOcrProcessingTimeoutMs()
         }
       );
     } catch (error) {
       if (isTimeoutError(error)) {
-        const timeoutMessage = buildTimeoutErrorMessage('OCR', 120000);
+        const timeoutMessage = buildTimeoutErrorMessage('OCR', getOcrProcessingTimeoutMs());
         console.error(`[TIMEOUT][OCR] Mistral OCR request timed out: ${error.message}`);
         throw new Error(timeoutMessage);
       }
@@ -214,7 +233,7 @@ class MistralOcrService {
           'Content-Type': 'application/json',
           ...authHeaders
         },
-        timeout: 120000
+        timeout: getOcrProcessingTimeoutMs()
       }
     );
 
@@ -262,7 +281,7 @@ class MistralOcrService {
             'Content-Type': 'application/json',
             ...authHeaders
           },
-          timeout: 120000
+          timeout: getOcrProcessingTimeoutMs()
         }
       );
 
@@ -301,7 +320,7 @@ class MistralOcrService {
       } catch (error) {
         if (isTimeoutError(error)) {
           console.error(`[TIMEOUT][OCR] Local OCR request timed out: ${error.message}`);
-          lastError = new Error(buildTimeoutErrorMessage('OCR', 120000));
+          lastError = new Error(buildTimeoutErrorMessage('OCR', getOcrProcessingTimeoutMs()));
           continue;
         }
         lastError = error;

--- a/services/setupService.js
+++ b/services/setupService.js
@@ -19,13 +19,16 @@ class SetupService {
     this.setupAiDetectionCache = new Map();
   }
 
-  normalizeValidationTimeoutMs(rawValue, fallbackValue = 30000) {
+  // maxMs defaults to 120s, the cap used for connection/availability checks.
+  // OCR document processing passes a higher cap (see OCR timeout handling) so a
+  // stored processing timeout can exceed the check ceiling.
+  normalizeValidationTimeoutMs(rawValue, fallbackValue = 30000, maxMs = 120000) {
     const parsed = Number.parseInt(String(rawValue ?? ''), 10);
     if (!Number.isFinite(parsed)) {
       return fallbackValue;
     }
 
-    return Math.min(Math.max(parsed, 1000), 120000);
+    return Math.min(Math.max(parsed, 1000), maxMs);
   }
 
   getValidationTimeoutMs() {

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -672,10 +672,10 @@
                                 <div class="space-y-2">
                                     <label for="ocrValidationTimeout" class="text-sm font-medium">OCR Timeout</label>
                                     <div class="flex items-center gap-3">
-                                        <input type="number" id="ocrValidationTimeout" name="ocrValidationTimeout" min="1" max="120" step="1" value="<%= Math.round(Number(config.SETUP_OCR_VALIDATION_TIMEOUT_MS || config.SETUP_VALIDATION_TIMEOUT_MS || 30000) / 1000) %>" class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                                        <input type="number" id="ocrValidationTimeout" name="ocrValidationTimeout" min="1" max="600" step="1" value="<%= Math.round(Number(config.SETUP_OCR_VALIDATION_TIMEOUT_MS || config.SETUP_VALIDATION_TIMEOUT_MS || 30000) / 1000) %>" class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                                         <span class="text-xs text-gray-500 whitespace-nowrap">seconds</span>
                                     </div>
-                                    <p class="text-xs text-gray-500">ENV: SETUP_OCR_VALIDATION_TIMEOUT_MS · Used for OCR model loading and OCR connection tests</p>
+                                    <p class="text-xs text-gray-500">ENV: SETUP_OCR_VALIDATION_TIMEOUT_MS · Used for OCR model loading, OCR connection tests, and OCR document processing. Connection tests stay capped at 120s; processing can use the full value.</p>
                                 </div>
                                 <div class="flex flex-wrap items-center gap-3">
                                     <button type="button" id="testOcrBtn" class="toolbar-btn toolbar-btn--warning flex items-center gap-2">


### PR DESCRIPTION
Closes #196

## Background

OCR document processing used a hard-coded **120 s** axios timeout, so large documents on slow local LLMs failed with a timeout and there was no way to raise the limit. The only adjustable OCR timeout (`SETUP_OCR_VALIDATION_TIMEOUT_MS`) applied to connection/model-load **checks** only — not to actual processing.

## Approach

Reuse the existing OCR timeout value for processing, but give processing its **own higher cap (600 s)** while the connection check stays capped at 120 s. No new setting.

## Changes

- **`services/mistralOcrService.js`** — the five hard `120000` timeouts (Mistral OCR, OpenAI-compatible + Ollama vision requests, and the two timeout error messages) now use `getOcrProcessingTimeoutMs()`: reads `SETUP_OCR_VALIDATION_TIMEOUT_MS` (fallback `SETUP_VALIDATION_TIMEOUT_MS`), own cap **600 s**, default **120 s** when unset/invalid. The 10 s model-discovery timeouts are unchanged.
- **`services/setupService.js`** — `normalizeValidationTimeoutMs()` gains an optional `maxMs` param (default `120000`); connection checks keep the 120 s ceiling.
- **`routes/setup.js`** — the OCR timeout is stored with a 600 s cap (setup wizard + settings update).
- **`views/settings.ejs`** — OCR Timeout field `max` raised 120 → 600 s; help text clarified.

## Reviewer notes

- **The connection check can never exceed 120 s**, even when a longer processing value is saved: its path (`withTemporaryValidationTimeout` → `normalizeValidationTimeoutMs` with the default `maxMs`) clamps to 120 s. Verified by test.
- **Default behaviour is unchanged** (120 s) for anyone who does not configure a value.
- Base is `v2026.07.01` (this branch builds on it; #208 is already merged there).
- No API endpoints changed, so the OpenAPI spec is untouched.

## Testing

- Unit-style checks of `getOcrProcessingTimeoutMs` (default / fallback / 600 s cap / 1 s min / invalid) and of the `maxMs` semantics: OCR save allows up to 600 s while the connection check clamps a stored 300 s value back to 120 s.
- ESLint shows no new errors.
- Manual end-to-end (slow local OCR model, raised timeout, large document) recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)