### PR TITLE
fix: guard against null loadConfig() in /settings and /setup routes (#192)

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -3683,15 +3683,17 @@ router.get('/setup', async (req, res) => {
     // Load saved config if it exists
     if (isEnvConfigured) {
       const savedConfig = await setupService.loadConfig();
-      if (savedConfig.PAPERLESS_API_URL) {
-        savedConfig.PAPERLESS_API_URL = savedConfig.PAPERLESS_API_URL.replace(/\/api$/, '');
+      if (savedConfig) {
+        if (savedConfig.PAPERLESS_API_URL) {
+          savedConfig.PAPERLESS_API_URL = savedConfig.PAPERLESS_API_URL.replace(/\/api$/, '');
+        }
+
+        savedConfig.TAGS = normalizeArray(savedConfig.TAGS);
+        savedConfig.IGNORE_TAGS = normalizeArray(savedConfig.IGNORE_TAGS);
+        savedConfig.PROMPT_TAGS = normalizeArray(savedConfig.PROMPT_TAGS);
+
+        config = { ...config, ...savedConfig };
       }
-
-      savedConfig.TAGS = normalizeArray(savedConfig.TAGS);
-      savedConfig.IGNORE_TAGS = normalizeArray(savedConfig.IGNORE_TAGS);
-      savedConfig.PROMPT_TAGS = normalizeArray(savedConfig.PROMPT_TAGS);
-
-      config = { ...config, ...savedConfig };
     }
 
     // Debug output
@@ -5470,15 +5472,17 @@ router.get('/settings', async (req, res) => {
   
   if (isConfigured) {
     const savedConfig = await setupService.loadConfig();
-    if (savedConfig.PAPERLESS_API_URL) {
-      savedConfig.PAPERLESS_API_URL = savedConfig.PAPERLESS_API_URL.replace(/\/api$/, '');
+    if (savedConfig) {
+      if (savedConfig.PAPERLESS_API_URL) {
+        savedConfig.PAPERLESS_API_URL = savedConfig.PAPERLESS_API_URL.replace(/\/api$/, '');
+      }
+
+      savedConfig.TAGS = normalizeArray(savedConfig.TAGS);
+      savedConfig.IGNORE_TAGS = normalizeArray(savedConfig.IGNORE_TAGS);
+      savedConfig.PROMPT_TAGS = normalizeArray(savedConfig.PROMPT_TAGS);
+
+      config = { ...config, ...savedConfig };
     }
-
-    savedConfig.TAGS = normalizeArray(savedConfig.TAGS);
-    savedConfig.IGNORE_TAGS = normalizeArray(savedConfig.IGNORE_TAGS);
-    savedConfig.PROMPT_TAGS = normalizeArray(savedConfig.PROMPT_TAGS);
-
-    config = { ...config, ...savedConfig };
   }
 
   // Debug-output


### PR DESCRIPTION
## Summary

- `setupService.loadConfig()` returns `null` in runtime-first mode when no runtime overrides exist (all config via Docker env vars)
- Both the `/setup` and `/settings` routes accessed `savedConfig.PAPERLESS_API_URL` without checking for `null`, causing an unhandled `TypeError`
- PM2 restarted the app on every `/settings` visit, making the page inaccessible

Fixes the null dereference by wrapping the `savedConfig` usage block with `if (savedConfig)` at both affected locations in `routes/setup.js`. When `savedConfig` is `null`, the routes skip the merge step and render using the already-populated env-derived config — which is the correct behavior.

Closes #192

## Test plan

- [ ] Run with `CONFIG_SOURCE_MODE=runtime-first` and no `runtime-overrides.json` (or an empty `{}`)
- [ ] `GET /settings` returns `302` → login (unauthenticated) and `200` (authenticated) — no crash, no PM2 restart
- [ ] `GET /setup` still works normally when overrides are present
- [ ] No `TypeError: Cannot read properties of null` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)