### PR TITLE
Add Long Text to custom field type selector

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -32,6 +32,7 @@ function formatStatus(status) {
 const TESTS = {
   'chat-document-search': 'test-chat-document-search.js',
   'chat-documents-service-search': 'test-chat-documents-service-search.js',
+  'custom-field-longtext-ui': 'test-custom-field-longtext-ui.js',
   'document-type-restriction': 'test-document-type-restriction.js',
   'effective-document-count-cache': 'test-effective-document-count-cache.js',
   'failed-reset-all': 'test-failed-reset-all.js',
@@ -65,6 +66,7 @@ const AREAS = {
   ocr: ['ocr-fallback-ai-errors', 'ocr-startup-recovery'],
   observability: ['log-level-config', 'log-level-logger'],
   processing: [
+    'custom-field-longtext-ui',
     'document-type-restriction',
     'ignore-tags-filter',
     'effective-document-count-cache',

--- a/tests/test-custom-field-longtext-ui.js
+++ b/tests/test-custom-field-longtext-ui.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function main() {
+  const settingsTemplate = fs.readFileSync(
+    path.join(__dirname, '..', 'views', 'settings.ejs'),
+    'utf8'
+  );
+
+  assert(
+    settingsTemplate.includes('<option value="longtext">Long Text</option>'),
+    'Expected the custom field type selector to include Long Text'
+  );
+}
+
+try {
+  main();
+  console.log('[PASS] Long Text custom field option is available in settings');
+} catch (error) {
+  console.error('[FAIL] Long Text custom field UI test failed:', error.message);
+  process.exitCode = 1;
+}

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -600,6 +600,7 @@
                                     <div class="col-span-3">
                                         <select id="newFieldType" onchange="toggleCurrencySelect()" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
                                             <option value="string">Text</option>
+                                            <option value="longtext">Long Text</option>
                                             <option value="float">Number</option>
                                             <option value="integer">Integer</option>
                                             <option value="monetary">Currency</option>


### PR DESCRIPTION
## Summary

Adds Paperless-ngx `longtext` as a selectable custom field type in the Paperless-AI Next settings UI.

Paperless-AI Next already preserves configured `longtext` custom fields through `CUSTOM_FIELDS`, and the shared custom field validator only applies the 128-character length guard to `string` fields. This change lets users select long text fields from the settings page instead of manually editing Docker environment JSON.

## Changes

- Adds `Long Text` / `longtext` to the custom field type dropdown in `views/settings.ejs`.
- Adds a lightweight regression test that checks the settings template exposes the `longtext` option.
- Registers the new test in the existing test runner under the processing area.

## Testing

```bash
node scripts/run-tests.js --test custom-field-longtext-ui
node --check scripts/run-tests.js
git diff --check
```
