### PR TITLE
feat: add full-page OCR support with configurable page range

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -353,7 +353,8 @@ module.exports = {
     provider: String(process.env.OCR_PROVIDER || process.env.MISTRAL_OCR_PROVIDER || 'mistral').trim().toLowerCase(),
     apiUrl: (process.env.OCR_API_URL || process.env.MISTRAL_OCR_API_URL || '').trim(),
     apiKey: process.env.OCR_API_KEY || process.env.MISTRAL_API_KEY || '',
-    model: process.env.MISTRAL_OCR_MODEL || 'mistral-ocr-latest'
+    model: process.env.MISTRAL_OCR_MODEL || 'mistral-ocr-latest',
+    fullPages: parseEnvBoolean(process.env.MISTRAL_OCR_FULL_PAGES, 'yes')
   },
   customFields: process.env.CUSTOM_FIELDS || '',
   aiProvider: process.env.AI_PROVIDER || 'openai',

--- a/services/mistralOcrService.js
+++ b/services/mistralOcrService.js
@@ -171,6 +171,19 @@ class MistralOcrService {
   }
 
   async performOcrWithOllama(base64, mimeType = 'application/pdf', documentId = null) {
+    // When fullPages is enabled and we have a PDF with a known document id,
+    // OCR every page individually for full document coverage (the thumbnail
+    // fallback below only covers page 1).
+    const fullPagesEnabled = config.mistralOcr?.fullPages === 'yes';
+    if (fullPagesEnabled && String(mimeType).toLowerCase().startsWith('application/pdf') && Number.isInteger(Number(documentId))) {
+      const fullText = await this.performOcrOnAllPages(Number(documentId));
+      if (fullText) {
+        return fullText;
+      }
+      // Fall through to thumbnail-based OCR if per-page extraction failed.
+      console.warn(`[OCR] Per-page OCR produced no text for document ${documentId}, falling back to thumbnail.`);
+    }
+
     let imageBase64 = base64;
     let imageMimeType = mimeType;
 
@@ -188,6 +201,54 @@ class MistralOcrService {
       imageMimeType = 'image/png';
     }
 
+    return this.performOcrOnImage(imageBase64, imageMimeType);
+  }
+
+  /**
+   * OCRs every page of a document by rendering each page to an image via the
+   * Paperless-ngx image endpoint, then running local OCR on each image. Page
+   * texts are concatenated in order. Returns null if no page produced text.
+   * @param {number} documentId
+   * @returns {Promise<string|null>}
+   */
+  async performOcrOnAllPages(documentId) {
+    const pageCount = await PaperlessService.getDocumentPageCount(documentId);
+    if (!pageCount || pageCount < 1) {
+      return null;
+    }
+
+    const MAX_PAGES = 100;
+    const limit = Math.min(pageCount, MAX_PAGES);
+    let accumulated = '';
+    let anySuccess = false;
+
+    for (let page = 1; page <= limit; page++) {
+      const pageBuffer = await PaperlessService.getDocumentPageImage(documentId, page);
+      if (!pageBuffer) {
+        break;
+      }
+      try {
+        const pageText = await this.performOcrOnImage(pageBuffer.toString('base64'), 'image/png');
+        if (pageText) {
+          accumulated += (accumulated ? '\n' : '') + pageText;
+          anySuccess = true;
+        }
+      } catch (err) {
+        console.warn(`[OCR] OCR failed for page ${page} of document ${documentId}: ${err.message}`);
+      }
+    }
+
+    return anySuccess ? accumulated : null;
+  }
+
+  /**
+   * Runs local OCR on a single base64-encoded image using the configured
+   * OpenAI-compatible or Ollama-compatible endpoint.
+   * @param {string} imageBase64
+   * @param {string} imageMimeType
+   * @returns {Promise<string>}
+   */
+  async performOcrOnImage(imageBase64, imageMimeType = 'image/png') {
     const normalizedApiBase = await this.resolveLocalOcrApiBase();
     const baseApiUrl = normalizedApiBase.replace(/\/v1$/i, '');
     const openAiApiUrl = /\/v1$/i.test(normalizedApiBase) ? normalizedApiBase : `${baseApiUrl}/v1`;
@@ -294,9 +355,9 @@ class MistralOcrService {
           () => runOpenAiLikeWithFallback(openAiApiUrl)
         ]
         : [
-        () => runOllamaLike(ollamaApiUrl),
-        () => runOpenAiLikeWithFallback(openAiApiUrl)
-      ];
+          () => runOllamaLike(ollamaApiUrl),
+          () => runOpenAiLikeWithFallback(openAiApiUrl)
+        ];
 
     let ocrText = '';
     let lastError;

--- a/services/paperlessService.js
+++ b/services/paperlessService.js
@@ -236,6 +236,48 @@ class PaperlessService {
     }
   }
 
+  /**
+   * Fetches a single rendered page of a document as a PNG image buffer.
+   * Uses the Paperless-ngx document image endpoint (?page=N), which renders
+   * the specified page server-side. Useful for full-page OCR.
+   * @param {number} documentId
+   * @param {number} page 1-indexed page number
+   * @returns {Promise<Buffer|null>}
+   */
+  async getDocumentPageImage(documentId, page = 1) {
+    this.initialize();
+    try {
+      const response = await this.client.get(`/documents/${documentId}/image/`, {
+        params: { page },
+        responseType: 'arraybuffer'
+      });
+      if (response.data && response.data.byteLength > 0) {
+        return Buffer.from(response.data);
+      }
+      return null;
+    } catch (error) {
+      console.error(`[ERROR] fetching page ${page} image for document ${documentId}:`, error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Returns the number of pages for a document, or null if unknown.
+   * @param {number} documentId
+   * @returns {Promise<number|null>}
+   */
+  async getDocumentPageCount(documentId) {
+    try {
+      const doc = await this.getDocument(documentId);
+      const count = doc && doc.page_count ? Number(doc.page_count) : null;
+      return Number.isFinite(count) && count > 0 ? count : null;
+    } catch (error) {
+      console.error(`[ERROR] fetching page count for document ${documentId}:`, error.message);
+      return null;
+    }
+  }
+
+
 
   // Aktualisiert den Tag-Cache, wenn er älter als CACHE_LIFETIME ist
   async ensureTagCache() {


### PR DESCRIPTION
## Summary

Extends the existing OCR rescue queue with **full-page OCR** capability. Previously, the Ollama-based OCR path only processed the document **thumbnail** (first page). This PR adds per-page image rendering and concatenated OCR for multi-page documents.

## Changes

### `services/paperlessService.js`
- **`getDocumentPageImage(documentId, page)`** — fetches a single rendered page from Paperless-ngx as a PNG buffer (uses the `?page=N` query param on the image endpoint)
- **`getDocumentPageCount(documentId)`** — reads the `page_count` field from the document metadata

### `services/mistralOcrService.js`
- **`performOcrOnAllPages(documentId)`** — iterates over all pages, OCRs each one, concatenates results
- **`performOcrOnImage(imageBase64, imageMimeType)`** — extracted the existing single-image OCR logic into a reusable method
- **`performOcrWithOllama()`** — updated to call `performOcrOnAllPages` when a PDF document ID is provided
- Configurable via **`MISTRAL_OCR_FULL_PAGES`** env var (default: `yes`, set to `no` to revert to thumbnail-only OCR)

### `config/config.js`
- Added `fullPages` option under `mistralOcr` section, controlled by `MISTRAL_OCR_FULL_PAGES`

## How it works

1. When OCR queue processes a PDF with Ollama provider
2. If `MISTRAL_OCR_FULL_PAGES=yes` (default), fetches the page count
3. Renders each page via `GET /api/documents/{id}/image/?page=N`
4. Sends each page image to the configured vision model (e.g. `glm-ocr:latest`)
5. Concatenates all extracted text and writes it back to Paperless-ngx

## Notes

- Falls back gracefully to thumbnail-only mode if per-page extraction fails or `MISTRAL_OCR_FULL_PAGES=no`
- Capped at 100 pages to prevent runaway processing