### PR TITLE
Dashboard fixes and README OCR vision clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ Connect to OpenAI, Ollama, or any OpenAI-compatible API. We've moved beyond simp
 Waging war against blurry scans, shaky smartphone photos, and handwritten scribbles that standard OCR usually chokes on. You can run OCR with:
 
 - Mistral OCR (`provider: mistral`)
-- local OpenAI-compatible vision APIs (`provider: ollama` + `/v1` endpoint, e.g. LM Studio-compatible)
+- local OpenAI-compatible vision APIs (`provider: ollama` + `/v1` endpoint, e.g. LM Studio, vLLM, or any other OpenAI-compatible server)
 - native Ollama chat vision APIs (`provider: ollama` + `/api/chat` endpoint)
+
+This isn't locked to one model. **Any vision-capable model your endpoint serves works** — for example `llama3.2-vision`, `gemma3`, `qwen2-vl`, `minicpm-v`, `moondream`, `pixtral`, `internvl`, or `llava`. During setup, **Quickstart** probes your endpoint and automatically detects which of its models are vision-capable, so you don't have to guess.
+
+Multi-page PDFs are also fully supported for local vision models: pages are rendered to images via `poppler` and sent to the model one by one, instead of only OCRing a single-page thumbnail (see [OCR Provider Notes](#ocr-provider-notes) below). Mistral OCR handles PDFs natively.
 
 The OCR setup now also validates real image reading instead of only checking endpoint reachability.
 

--- a/config/changelog.js
+++ b/config/changelog.js
@@ -44,10 +44,10 @@ const RELEASES = [
   {
     version: 'v2026.07.03',
     entries: [
-      'New: Multi-page PDF OCR for local vision models - PDF pages are rendered via poppler (pdftoppm) and sent page by page (OCR_PDF_RENDER_ENABLED, OCR_PDF_RENDER_MAX_PAGES, OCR_PDF_RENDER_DPI)',
+      'New: Multi-page PDF OCR for local vision models - PDF pages are rendered via poppler (pdftoppm) and sent page by page',
       'Improvement: Saving settings no longer runs live AI/OCR connection tests - use the explicit test buttons to verify connectivity on demand',
       'Improvement: Settings page cleaned up - unified ON/OFF switches and clearer section grouping',
-      'Fix: Reconciliation settings (RECONCILIATION_ENABLED, RECONCILIATION_INTERVAL) are now actually persisted when saved from the settings page',
+      'Fix: Reconciliation settings are now actually persisted when saved from the settings page',
       'Removed: Legacy data/.env migration notice on the settings page',
     ],
   },

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -151,6 +151,7 @@ class DashboardStatsLoader {
         this.loadingSubtext = document.getElementById('dashboardLoadingSubtext');
         this.loadingBannerTimer = null;
         this.loadingBannerVisible = false;
+        this.refreshInFlight = false;
     }
 
     setLoadingProgress(percent, message = '', subtext = '', options = {}) {
@@ -488,14 +489,18 @@ class DashboardStatsLoader {
 
     updateCards(stats) {
         const documentCount = stats.paperless_data.documentCount;
-        const processedCount = Math.min(stats.paperless_data.processedDocumentCount, documentCount);
+        const processedCount = Math.max(0, Number(stats.paperless_data.processedDocumentCount || 0));
         const ocrNeededCount = Math.max(0, stats.paperless_data.ocrNeededCount || 0);
         const failedCount = Math.max(0, stats.paperless_data.failedCount || 0);
         const queueBacklog = Math.max(0, stats.paperless_data.queueBacklog || 0);
         const efficiencyRate = Math.max(0, Number(stats.paperless_data.processingEfficiencyRate || 0));
         const failedRate = Math.max(0, Number(stats.paperless_data.failedRate || 0));
         const processedToday = Math.max(0, Number(stats.paperless_data.processedToday || 0));
-        const unprocessedCount = Math.max(0, documentCount - processedCount - ocrNeededCount - failedCount);
+        // Only the "Unprocessed" card needs processedCount capped to documentCount, so that
+        // an all-time processed total exceeding the current live scan-scope count can't push
+        // this figure negative. The headline processedCount above must stay uncapped.
+        const chartSafeProcessedCount = Math.min(processedCount, documentCount);
+        const unprocessedCount = Math.max(0, documentCount - chartSafeProcessedCount - ocrNeededCount - failedCount);
 
         this.setText('processedCountValue', this.formatNumber(processedCount));
         this.setText('ocrNeededCountValue', this.formatNumber(ocrNeededCount));
@@ -579,6 +584,56 @@ class DashboardStatsLoader {
             }
             this.setLoadingProgress(100, 'Dashboard ready', 'Live updates will continue in the background.');
             this.setLoadingState(false);
+        }
+    }
+
+    // Silent background refresh used for live updates (e.g. a document just finished
+    // processing). Unlike load(), this never toggles the loading skeletons, so the
+    // cards and activity list update in place without flickering.
+    async refresh() {
+        if (this.refreshInFlight) return;
+        this.refreshInFlight = true;
+
+        try {
+            const abortController = new AbortController();
+            const timeoutId = setTimeout(() => abortController.abort(), this.requestTimeoutMs);
+
+            const response = await fetch('/api/dashboard/stats', {
+                signal: abortController.signal
+            });
+            clearTimeout(timeoutId);
+
+            if (!response.ok) {
+                throw new Error('Failed to refresh dashboard stats');
+            }
+
+            const payload = await response.json();
+            if (!payload?.success) {
+                throw new Error(payload?.error || 'Invalid dashboard stats response');
+            }
+
+            window.dashboardData = {
+                documentCount: payload.paperless_data.documentCount,
+                processedCount: payload.paperless_data.processedDocumentCount,
+                ocrNeededCount: payload.paperless_data.ocrNeededCount,
+                failedCount: payload.paperless_data.failedCount,
+                tokenDistribution: payload.paperless_data.tokenDistribution,
+                documentTypes: payload.paperless_data.documentTypes,
+                tokenTrend: payload.paperless_data.tokenTrend,
+                recentActivity: payload.paperless_data.recentActivity,
+                languageDistribution: payload.paperless_data.languageDistribution,
+                queueBacklog: payload.paperless_data.queueBacklog,
+                processingEfficiencyRate: payload.paperless_data.processingEfficiencyRate,
+                failedRate: payload.paperless_data.failedRate,
+                processedToday: payload.paperless_data.processedToday
+            };
+
+            this.updateCards(payload);
+            this.updateCharts(payload);
+        } catch (error) {
+            console.error('Error refreshing dashboard stats:', error);
+        } finally {
+            this.refreshInFlight = false;
         }
     }
 }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,384 +1,452 @@
+/* global Chart */
 function resolveDashboardData() {
-    if (window.dashboardData && typeof window.dashboardData === 'object') {
-        return window.dashboardData;
-    }
+  if (window.dashboardData && typeof window.dashboardData === 'object') {
+    return window.dashboardData;
+  }
 
-    const payloadElement = document.getElementById('dashboardDataPayload');
-    if (!payloadElement) {
-        return {
-            documentCount: 0,
-            processedCount: 0,
-            ocrNeededCount: 0,
-            failedCount: 0,
-            queueBacklog: 0,
-            processingEfficiencyRate: 0,
-            failedRate: 0,
-            processedToday: 0,
-            tokenDistribution: [],
-            documentTypes: [],
-            tokenTrend: [],
-            recentActivity: [],
-            languageDistribution: []
-        };
-    }
-
-    let parsedData = {};
-    try {
-        parsedData = JSON.parse(payloadElement.textContent || '{}');
-    } catch (error) {
-        console.error('Failed to parse dashboardDataPayload:', error);
-    }
-
-    const resolved = {
-        documentCount: Number(parsedData.documentCount || 0),
-        processedCount: Number(parsedData.processedDocumentCount || 0),
-        ocrNeededCount: Number(parsedData.ocrNeededCount || 0),
-        failedCount: Number(parsedData.failedCount || 0),
-        queueBacklog: Number(parsedData.queueBacklog || 0),
-        processingEfficiencyRate: Number(parsedData.processingEfficiencyRate || 0),
-        failedRate: Number(parsedData.failedRate || 0),
-        processedToday: Number(parsedData.processedToday || 0),
-        tokenDistribution: Array.isArray(parsedData.tokenDistribution) ? parsedData.tokenDistribution : [],
-        documentTypes: Array.isArray(parsedData.documentTypes) ? parsedData.documentTypes : [],
-        tokenTrend: Array.isArray(parsedData.tokenTrend) ? parsedData.tokenTrend : [],
-        recentActivity: Array.isArray(parsedData.recentActivity) ? parsedData.recentActivity : [],
-        languageDistribution: Array.isArray(parsedData.languageDistribution) ? parsedData.languageDistribution : []
+  const payloadElement = document.getElementById('dashboardDataPayload');
+  if (!payloadElement) {
+    return {
+      documentCount: 0,
+      processedCount: 0,
+      ocrNeededCount: 0,
+      failedCount: 0,
+      queueBacklog: 0,
+      processingEfficiencyRate: 0,
+      failedRate: 0,
+      processedToday: 0,
+      tokenDistribution: [],
+      documentTypes: [],
+      tokenTrend: [],
+      recentActivity: [],
+      languageDistribution: [],
     };
+  }
 
-    window.dashboardData = resolved;
-    return resolved;
+  let parsedData = {};
+  try {
+    parsedData = JSON.parse(payloadElement.textContent || '{}');
+  } catch (error) {
+    console.error('Failed to parse dashboardDataPayload:', error);
+  }
+
+  const resolved = {
+    documentCount: Number(parsedData.documentCount || 0),
+    processedCount: Number(parsedData.processedDocumentCount || 0),
+    ocrNeededCount: Number(parsedData.ocrNeededCount || 0),
+    failedCount: Number(parsedData.failedCount || 0),
+    queueBacklog: Number(parsedData.queueBacklog || 0),
+    processingEfficiencyRate: Number(parsedData.processingEfficiencyRate || 0),
+    failedRate: Number(parsedData.failedRate || 0),
+    processedToday: Number(parsedData.processedToday || 0),
+    tokenDistribution: Array.isArray(parsedData.tokenDistribution)
+      ? parsedData.tokenDistribution
+      : [],
+    documentTypes: Array.isArray(parsedData.documentTypes)
+      ? parsedData.documentTypes
+      : [],
+    tokenTrend: Array.isArray(parsedData.tokenTrend)
+      ? parsedData.tokenTrend
+      : [],
+    recentActivity: Array.isArray(parsedData.recentActivity)
+      ? parsedData.recentActivity
+      : [],
+    languageDistribution: Array.isArray(parsedData.languageDistribution)
+      ? parsedData.languageDistribution
+      : [],
+  };
+
+  window.dashboardData = resolved;
+  return resolved;
 }
 
 function escapeHtml(value) {
-    return String(value)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
-const dashboardPaperlessPublicUrl = (typeof window.paperlessPublicUrl === 'string' ? window.paperlessPublicUrl : '').replace(/\/$/, '');
+const dashboardPaperlessPublicUrl = (
+  typeof window.paperlessPublicUrl === 'string' ? window.paperlessPublicUrl : ''
+).replace(/\/$/, '');
 
 // Chart Initialization
 class ChartManager {
-    constructor() {
-        this.documentChart = null;
-        this.initializeDocumentChart();
+  constructor() {
+    this.documentChart = null;
+    this.initializeDocumentChart();
+  }
+
+  initializeDocumentChart() {
+    const dashboardData = resolveDashboardData();
+    const {
+      documentCount,
+      processedCount,
+      ocrNeededCount = 0,
+      failedCount = 0,
+    } = dashboardData;
+    const remainingCount = Math.max(
+      0,
+      documentCount - processedCount - ocrNeededCount - failedCount
+    );
+
+    const chartElement = document.getElementById('documentChart');
+    if (!chartElement || typeof Chart === 'undefined') {
+      return;
     }
 
-    initializeDocumentChart() {
-        const dashboardData = resolveDashboardData();
-        const {
-            documentCount,
-            processedCount,
-            ocrNeededCount = 0,
-            failedCount = 0
-        } = dashboardData;
-        const remainingCount = Math.max(0, documentCount - processedCount - ocrNeededCount - failedCount);
+    const ctx = chartElement.getContext('2d');
+    if (!ctx) {
+      return;
+    }
 
-        const chartElement = document.getElementById('documentChart');
-        if (!chartElement || typeof Chart === 'undefined') {
-            return;
-        }
-
-        const ctx = chartElement.getContext('2d');
-        if (!ctx) {
-            return;
-        }
-
-        this.documentChart = new Chart(ctx, {
-            type: 'doughnut',
-            data: {
-                labels: ['AI Processed', 'OCR Needed', 'Failed', 'Unprocessed'],
-                datasets: [{
-                    data: [processedCount, ocrNeededCount, failedCount, remainingCount],
-                    backgroundColor: [
-                        '#3b82f6',  // blue-500
-                        '#f59e0b',  // amber-500
-                        '#ef4444',  // red-500
-                        '#e2e8f0'   // gray-200
-                    ],
-                    borderWidth: 0,
-                    spacing: 2
-                }]
+    this.documentChart = new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['AI Processed', 'OCR Needed', 'Failed', 'Unprocessed'],
+        datasets: [
+          {
+            data: [processedCount, ocrNeededCount, failedCount, remainingCount],
+            backgroundColor: [
+              '#3b82f6', // blue-500
+              '#f59e0b', // amber-500
+              '#ef4444', // red-500
+              '#e2e8f0', // gray-200
+            ],
+            borderWidth: 0,
+            spacing: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: '70%',
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              label: function (context) {
+                const value = context.raw;
+                const total = context.dataset.data.reduce(
+                  (sum, current) => sum + Number(current || 0),
+                  0
+                );
+                const percentage = ((value / total) * 100).toFixed(1);
+                return `${value} (${percentage}%)`;
+              },
             },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                cutout: '70%',
-                plugins: {
-                    legend: {
-                        display: false
-                    },
-                    tooltip: {
-                        callbacks: {
-                            label: function(context) {
-                                const value = context.raw;
-                                const total = context.dataset.data.reduce((sum, current) => sum + Number(current || 0), 0);
-                                const percentage = ((value / total) * 100).toFixed(1);
-                                return `${value} (${percentage}%)`;
-                            }
-                        }
-                    }
-                }
-            }
-        });
-    }
+          },
+        },
+      },
+    });
+  }
 
-    updateDocumentChart(documentCount, processedCount, ocrNeededCount = 0, failedCount = 0) {
-        if (!this.documentChart) return;
+  updateDocumentChart(
+    documentCount,
+    processedCount,
+    ocrNeededCount = 0,
+    failedCount = 0
+  ) {
+    if (!this.documentChart) return;
 
-        const safeProcessed = Math.min(processedCount, documentCount);
-        const safeOcrNeeded = Math.max(0, ocrNeededCount);
-        const safeFailed = Math.max(0, failedCount);
-        const unprocessedCount = Math.max(0, documentCount - safeProcessed - safeOcrNeeded - safeFailed);
+    const safeProcessed = Math.min(processedCount, documentCount);
+    const safeOcrNeeded = Math.max(0, ocrNeededCount);
+    const safeFailed = Math.max(0, failedCount);
+    const unprocessedCount = Math.max(
+      0,
+      documentCount - safeProcessed - safeOcrNeeded - safeFailed
+    );
 
-        this.documentChart.data.datasets[0].data = [safeProcessed, safeOcrNeeded, safeFailed, unprocessedCount];
-        this.documentChart.update();
-    }
+    this.documentChart.data.datasets[0].data = [
+      safeProcessed,
+      safeOcrNeeded,
+      safeFailed,
+      unprocessedCount,
+    ];
+    this.documentChart.update();
+  }
 }
 
 class DashboardStatsLoader {
-    constructor() {
-        this.minimumLoadingTimeMs = 400;
-        this.requestTimeoutMs = 15000;
-        this.loadingBannerDelayMs = 1000;
-        this.loadingBlock = document.getElementById('dashboardLoadingBlock');
-        this.loadingProgress = document.getElementById('dashboardLoadingProgress');
-        this.loadingPercent = document.getElementById('dashboardLoadingPercent');
-        this.loadingMessage = document.getElementById('dashboardLoadingMessage');
-        this.loadingSubtext = document.getElementById('dashboardLoadingSubtext');
-        this.loadingBannerTimer = null;
-        this.loadingBannerVisible = false;
-        this.refreshInFlight = false;
+  constructor() {
+    this.minimumLoadingTimeMs = 400;
+    this.requestTimeoutMs = 15000;
+    this.loadingBannerDelayMs = 1000;
+    this.loadingBlock = document.getElementById('dashboardLoadingBlock');
+    this.loadingProgress = document.getElementById('dashboardLoadingProgress');
+    this.loadingPercent = document.getElementById('dashboardLoadingPercent');
+    this.loadingMessage = document.getElementById('dashboardLoadingMessage');
+    this.loadingSubtext = document.getElementById('dashboardLoadingSubtext');
+    this.loadingBannerTimer = null;
+    this.loadingBannerVisible = false;
+    this.refreshInFlight = false;
+  }
+
+  setLoadingProgress(percent, message = '', subtext = '', options = {}) {
+    const safePercent = Math.max(0, Math.min(100, Number(percent || 0)));
+    const keepIndeterminate = Boolean(options.keepIndeterminate);
+
+    if (this.loadingProgress) {
+      if (keepIndeterminate) {
+        this.loadingProgress.classList.add('is-indeterminate');
+        this.loadingProgress.style.width = '38%';
+      } else {
+        this.loadingProgress.classList.remove('is-indeterminate');
+        this.loadingProgress.style.width = `${safePercent}%`;
+      }
     }
 
-    setLoadingProgress(percent, message = '', subtext = '', options = {}) {
-        const safePercent = Math.max(0, Math.min(100, Number(percent || 0)));
-        const keepIndeterminate = Boolean(options.keepIndeterminate);
-
-        if (this.loadingProgress) {
-            if (keepIndeterminate) {
-                this.loadingProgress.classList.add('is-indeterminate');
-                this.loadingProgress.style.width = '38%';
-            } else {
-                this.loadingProgress.classList.remove('is-indeterminate');
-                this.loadingProgress.style.width = `${safePercent}%`;
-            }
-        }
-
-        if (this.loadingPercent) {
-            this.loadingPercent.textContent = keepIndeterminate ? '...' : `${Math.round(safePercent)}%`;
-        }
-
-        if (this.loadingMessage && message) {
-            this.loadingMessage.textContent = message;
-        }
-
-        if (this.loadingSubtext && subtext) {
-            this.loadingSubtext.textContent = subtext;
-        }
+    if (this.loadingPercent) {
+      this.loadingPercent.textContent = keepIndeterminate
+        ? '...'
+        : `${Math.round(safePercent)}%`;
     }
 
-    getFallbackStats() {
-        const dashboardData = resolveDashboardData() || {};
-        return {
-            paperless_data: {
-                documentCount: Number(dashboardData.documentCount || 0),
-                processedDocumentCount: Number(dashboardData.processedCount || 0),
-                ocrNeededCount: Number(dashboardData.ocrNeededCount || 0),
-                failedCount: Number(dashboardData.failedCount || 0),
-                queueBacklog: Number(dashboardData.queueBacklog || 0),
-                processingEfficiencyRate: Number(dashboardData.processingEfficiencyRate || 0),
-                failedRate: Number(dashboardData.failedRate || 0),
-                processedToday: Number(dashboardData.processedToday || 0),
-                tagCount: Number(dashboardData.tagCount || 0),
-                correspondentCount: Number(dashboardData.correspondentCount || 0),
-                tokenDistribution: Array.isArray(dashboardData.tokenDistribution) ? dashboardData.tokenDistribution : [],
-                documentTypes: Array.isArray(dashboardData.documentTypes) ? dashboardData.documentTypes : [],
-                tokenTrend: Array.isArray(dashboardData.tokenTrend) ? dashboardData.tokenTrend : [],
-                recentActivity: Array.isArray(dashboardData.recentActivity) ? dashboardData.recentActivity : [],
-                languageDistribution: Array.isArray(dashboardData.languageDistribution) ? dashboardData.languageDistribution : []
-            },
-            openai_data: {
-                averagePromptTokens: Number(dashboardData.averagePromptTokens || 0),
-                averageCompletionTokens: Number(dashboardData.averageCompletionTokens || 0),
-                averageTotalTokens: Number(dashboardData.averageTotalTokens || 0),
-                tokensOverall: Number(dashboardData.tokensOverall || 0)
-            }
-        };
+    if (this.loadingMessage && message) {
+      this.loadingMessage.textContent = message;
     }
 
-    setLoadingState(isLoading) {
-        if (this.loadingBlock) {
-            if (isLoading) {
-                if (this.loadingBannerTimer) {
-                    clearTimeout(this.loadingBannerTimer);
-                    this.loadingBannerTimer = null;
-                }
+    if (this.loadingSubtext && subtext) {
+      this.loadingSubtext.textContent = subtext;
+    }
+  }
 
-                if (!this.loadingBannerVisible) {
-                    this.loadingBannerTimer = setTimeout(() => {
-                        this.loadingBlock.classList.remove('hidden');
-                        requestAnimationFrame(() => {
-                            this.loadingBlock.classList.remove('opacity-0');
-                            this.loadingBlock.classList.add('opacity-100');
-                        });
-                        this.loadingBannerVisible = true;
-                        this.loadingBannerTimer = null;
-                    }, this.loadingBannerDelayMs);
-                }
-            } else {
-                if (this.loadingBannerTimer) {
-                    clearTimeout(this.loadingBannerTimer);
-                    this.loadingBannerTimer = null;
-                }
+  getFallbackStats() {
+    const dashboardData = resolveDashboardData() || {};
+    return {
+      paperless_data: {
+        documentCount: Number(dashboardData.documentCount || 0),
+        processedDocumentCount: Number(dashboardData.processedCount || 0),
+        ocrNeededCount: Number(dashboardData.ocrNeededCount || 0),
+        failedCount: Number(dashboardData.failedCount || 0),
+        queueBacklog: Number(dashboardData.queueBacklog || 0),
+        processingEfficiencyRate: Number(
+          dashboardData.processingEfficiencyRate || 0
+        ),
+        failedRate: Number(dashboardData.failedRate || 0),
+        processedToday: Number(dashboardData.processedToday || 0),
+        tagCount: Number(dashboardData.tagCount || 0),
+        correspondentCount: Number(dashboardData.correspondentCount || 0),
+        tokenDistribution: Array.isArray(dashboardData.tokenDistribution)
+          ? dashboardData.tokenDistribution
+          : [],
+        documentTypes: Array.isArray(dashboardData.documentTypes)
+          ? dashboardData.documentTypes
+          : [],
+        tokenTrend: Array.isArray(dashboardData.tokenTrend)
+          ? dashboardData.tokenTrend
+          : [],
+        recentActivity: Array.isArray(dashboardData.recentActivity)
+          ? dashboardData.recentActivity
+          : [],
+        languageDistribution: Array.isArray(dashboardData.languageDistribution)
+          ? dashboardData.languageDistribution
+          : [],
+      },
+      openai_data: {
+        averagePromptTokens: Number(dashboardData.averagePromptTokens || 0),
+        averageCompletionTokens: Number(
+          dashboardData.averageCompletionTokens || 0
+        ),
+        averageTotalTokens: Number(dashboardData.averageTotalTokens || 0),
+        tokensOverall: Number(dashboardData.tokensOverall || 0),
+      },
+    };
+  }
 
-                if (this.loadingBannerVisible) {
-                    this.loadingBlock.classList.remove('opacity-100');
-                    this.loadingBlock.classList.add('opacity-0');
-                    setTimeout(() => {
-                        this.loadingBlock.classList.add('hidden');
-                        this.loadingBannerVisible = false;
-                    }, 300);
-                } else {
-                    this.loadingBlock.classList.add('hidden');
-                    this.loadingBlock.classList.remove('opacity-100');
-                    this.loadingBlock.classList.add('opacity-0');
-                }
-            }
-            this.loadingBlock.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+  setLoadingState(isLoading) {
+    if (this.loadingBlock) {
+      if (isLoading) {
+        if (this.loadingBannerTimer) {
+          clearTimeout(this.loadingBannerTimer);
+          this.loadingBannerTimer = null;
         }
 
-        const chartSkeletonElements = document.querySelectorAll('[data-dashboard-chart-skeleton]');
-        chartSkeletonElements.forEach((skeletonElement) => {
-            skeletonElement.classList.toggle('hidden', !isLoading);
-            skeletonElement.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
-            skeletonElement.setAttribute('aria-busy', isLoading ? 'true' : 'false');
-        });
+        if (!this.loadingBannerVisible) {
+          this.loadingBannerTimer = setTimeout(() => {
+            this.loadingBlock.classList.remove('hidden');
+            requestAnimationFrame(() => {
+              this.loadingBlock.classList.remove('opacity-0');
+              this.loadingBlock.classList.add('opacity-100');
+            });
+            this.loadingBannerVisible = true;
+            this.loadingBannerTimer = null;
+          }, this.loadingBannerDelayMs);
+        }
+      } else {
+        if (this.loadingBannerTimer) {
+          clearTimeout(this.loadingBannerTimer);
+          this.loadingBannerTimer = null;
+        }
 
-        const valueElements = document.querySelectorAll('[data-dashboard-value]');
-        valueElements.forEach((valueElement) => {
-            valueElement.classList.toggle('hidden', isLoading);
-            valueElement.setAttribute('aria-hidden', isLoading ? 'true' : 'false');
-
-            const skeleton = document.getElementById(`${valueElement.id}Skeleton`);
-            if (!skeleton) return;
-            skeleton.classList.toggle('hidden', !isLoading);
-            skeleton.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
-            skeleton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
-        });
-
-        const listSkeletonElements = document.querySelectorAll('[data-dashboard-list-skeleton]');
-        listSkeletonElements.forEach((skeletonElement) => {
-            skeletonElement.classList.toggle('hidden', !isLoading);
-            skeletonElement.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
-            skeletonElement.setAttribute('aria-busy', isLoading ? 'true' : 'false');
-        });
-
-        const listContentElements = document.querySelectorAll('[data-dashboard-list-content]');
-        listContentElements.forEach((contentElement) => {
-            contentElement.classList.toggle('hidden', isLoading);
-            contentElement.setAttribute('aria-hidden', isLoading ? 'true' : 'false');
-        });
+        if (this.loadingBannerVisible) {
+          this.loadingBlock.classList.remove('opacity-100');
+          this.loadingBlock.classList.add('opacity-0');
+          setTimeout(() => {
+            this.loadingBlock.classList.add('hidden');
+            this.loadingBannerVisible = false;
+          }, 300);
+        } else {
+          this.loadingBlock.classList.add('hidden');
+          this.loadingBlock.classList.remove('opacity-100');
+          this.loadingBlock.classList.add('opacity-0');
+        }
+      }
+      this.loadingBlock.setAttribute('aria-busy', isLoading ? 'true' : 'false');
     }
 
-    formatNumber(value, options = {}) {
-        const numericValue = Number(value || 0);
-        if (!Number.isFinite(numericValue)) {
-            return '0';
-        }
+    const chartSkeletonElements = document.querySelectorAll(
+      '[data-dashboard-chart-skeleton]'
+    );
+    chartSkeletonElements.forEach((skeletonElement) => {
+      skeletonElement.classList.toggle('hidden', !isLoading);
+      skeletonElement.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
+      skeletonElement.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+    });
 
-        if (!options.compact || Math.abs(numericValue) < 1000) {
-            return numericValue.toLocaleString();
-        }
+    const valueElements = document.querySelectorAll('[data-dashboard-value]');
+    valueElements.forEach((valueElement) => {
+      valueElement.classList.toggle('hidden', isLoading);
+      valueElement.setAttribute('aria-hidden', isLoading ? 'true' : 'false');
 
-        const absoluteValue = Math.abs(numericValue);
-        const units = [
-            { threshold: 1000000000, suffix: 'b' },
-            { threshold: 1000000, suffix: 'm' },
-            { threshold: 1000, suffix: 'k' }
-        ];
+      const skeleton = document.getElementById(`${valueElement.id}Skeleton`);
+      if (!skeleton) return;
+      skeleton.classList.toggle('hidden', !isLoading);
+      skeleton.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
+      skeleton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+    });
 
-        const unit = units.find((entry) => absoluteValue >= entry.threshold) || units[units.length - 1];
-        const scaledValue = numericValue / unit.threshold;
-        const rounded = Math.round(scaledValue * 10) / 10;
-        const compactValue = Number.isInteger(rounded)
-            ? String(rounded)
-            : rounded.toFixed(1).replace(/\.0$/, '');
+    const listSkeletonElements = document.querySelectorAll(
+      '[data-dashboard-list-skeleton]'
+    );
+    listSkeletonElements.forEach((skeletonElement) => {
+      skeletonElement.classList.toggle('hidden', !isLoading);
+      skeletonElement.setAttribute('aria-hidden', isLoading ? 'false' : 'true');
+      skeletonElement.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+    });
 
-        return `${compactValue}${unit.suffix}`;
+    const listContentElements = document.querySelectorAll(
+      '[data-dashboard-list-content]'
+    );
+    listContentElements.forEach((contentElement) => {
+      contentElement.classList.toggle('hidden', isLoading);
+      contentElement.setAttribute('aria-hidden', isLoading ? 'true' : 'false');
+    });
+  }
+
+  formatNumber(value, options = {}) {
+    const numericValue = Number(value || 0);
+    if (!Number.isFinite(numericValue)) {
+      return '0';
     }
 
-    setText(id, value) {
-        const element = document.getElementById(id);
-        if (!element) return;
-        element.textContent = value;
+    if (!options.compact || Math.abs(numericValue) < 1000) {
+      return numericValue.toLocaleString();
     }
 
-    updateCharts(stats) {
-        if (window.chartManager) {
-            window.chartManager.updateDocumentChart(
-                stats.paperless_data.documentCount,
-                stats.paperless_data.processedDocumentCount,
-                stats.paperless_data.ocrNeededCount,
-                stats.paperless_data.failedCount
-            );
-        }
+    const absoluteValue = Math.abs(numericValue);
+    const units = [
+      { threshold: 1000000000, suffix: 'b' },
+      { threshold: 1000000, suffix: 'm' },
+      { threshold: 1000, suffix: 'k' },
+    ];
 
-        const tokenChart = window.dashboardCharts?.tokenDistribution;
-        if (tokenChart) {
-            const distribution = Array.isArray(stats.paperless_data.tokenDistribution)
-                ? stats.paperless_data.tokenDistribution
-                : [];
-            tokenChart.data.labels = distribution.map(dist => dist.range);
-            tokenChart.data.datasets[0].data = distribution.map(dist => dist.count);
-            tokenChart.update();
-        }
+    const unit =
+      units.find((entry) => absoluteValue >= entry.threshold) ||
+      units[units.length - 1];
+    const scaledValue = numericValue / unit.threshold;
+    const rounded = Math.round(scaledValue * 10) / 10;
+    const compactValue = Number.isInteger(rounded)
+      ? String(rounded)
+      : rounded.toFixed(1).replace(/\.0$/, '');
 
-        const typesChart = window.dashboardCharts?.documentTypes;
-        if (typesChart) {
-            const documentTypes = Array.isArray(stats.paperless_data.documentTypes)
-                ? stats.paperless_data.documentTypes
-                : [];
-            typesChart.data.labels = documentTypes.map(type => type.type);
-            typesChart.data.datasets[0].data = documentTypes.map(type => type.count);
-            typesChart.update();
-        }
+    return `${compactValue}${unit.suffix}`;
+  }
 
-        const trendChart = window.dashboardCharts?.tokenTrend;
-        if (trendChart) {
-            const trend = Array.isArray(stats.paperless_data.tokenTrend)
-                ? stats.paperless_data.tokenTrend
-                : [];
-            trendChart.data.labels = trend.map(point => point.day);
-            trendChart.data.datasets[0].data = trend.map(point => point.totalTokens);
-            trendChart.update();
-        }
+  setText(id, value) {
+    const element = document.getElementById(id);
+    if (!element) return;
+    element.textContent = value;
+  }
+
+  updateCharts(stats) {
+    if (window.chartManager) {
+      window.chartManager.updateDocumentChart(
+        stats.paperless_data.documentCount,
+        stats.paperless_data.processedDocumentCount,
+        stats.paperless_data.ocrNeededCount,
+        stats.paperless_data.failedCount
+      );
     }
 
-    renderRecentActivity(items) {
-        const container = document.getElementById('recentActivityList');
-        if (!container) return;
+    const tokenChart = window.dashboardCharts?.tokenDistribution;
+    if (tokenChart) {
+      const distribution = Array.isArray(stats.paperless_data.tokenDistribution)
+        ? stats.paperless_data.tokenDistribution
+        : [];
+      tokenChart.data.labels = distribution.map((dist) => dist.range);
+      tokenChart.data.datasets[0].data = distribution.map((dist) => dist.count);
+      tokenChart.update();
+    }
 
-        const safeItems = Array.isArray(items) ? items : [];
-        if (safeItems.length === 0) {
-            container.innerHTML = '<div class="activity-item"><span class="activity-item-title">No recent processing activity available.</span></div>';
-            return;
-        }
+    const typesChart = window.dashboardCharts?.documentTypes;
+    if (typesChart) {
+      const documentTypes = Array.isArray(stats.paperless_data.documentTypes)
+        ? stats.paperless_data.documentTypes
+        : [];
+      typesChart.data.labels = documentTypes.map((type) => type.type);
+      typesChart.data.datasets[0].data = documentTypes.map(
+        (type) => type.count
+      );
+      typesChart.update();
+    }
 
-        container.innerHTML = safeItems.map((item) => {
-            const title = this.escapeHtml(item.title || 'Untitled document');
-            const docId = Number(item.documentId || 0);
-            const correspondent = this.escapeHtml(item.correspondent || 'Unknown correspondent');
-            const datePill = this.escapeHtml(this.formatDateForPill(item.createdAt));
-            const docUrl = this.getPaperlessDocumentUrl(docId);
-            const idPill = docId > 0 ? `#${docId}` : '#n/a';
-            const idPillHtml = docUrl
-                ? `<a href="${this.escapeHtml(docUrl)}" target="_blank" class="manual-search-pill id dashboard-doc-link" title="Open in Paperless">${idPill}</a>`
-                : `<span class="manual-search-pill id">${idPill}</span>`;
-            return `
+    const trendChart = window.dashboardCharts?.tokenTrend;
+    if (trendChart) {
+      const trend = Array.isArray(stats.paperless_data.tokenTrend)
+        ? stats.paperless_data.tokenTrend
+        : [];
+      trendChart.data.labels = trend.map((point) => point.day);
+      trendChart.data.datasets[0].data = trend.map(
+        (point) => point.totalTokens
+      );
+      trendChart.update();
+    }
+  }
+
+  renderRecentActivity(items) {
+    const container = document.getElementById('recentActivityList');
+    if (!container) return;
+
+    const safeItems = Array.isArray(items) ? items : [];
+    if (safeItems.length === 0) {
+      container.innerHTML =
+        '<div class="activity-item"><span class="activity-item-title">No recent processing activity available.</span></div>';
+      return;
+    }
+
+    container.innerHTML = safeItems
+      .map((item) => {
+        const title = this.escapeHtml(item.title || 'Untitled document');
+        const docId = Number(item.documentId || 0);
+        const correspondent = this.escapeHtml(
+          item.correspondent || 'Unknown correspondent'
+        );
+        const datePill = this.escapeHtml(
+          this.formatDateForPill(item.createdAt)
+        );
+        const docUrl = this.getPaperlessDocumentUrl(docId);
+        const idPill = docId > 0 ? `#${docId}` : '#n/a';
+        const idPillHtml = docUrl
+          ? `<a href="${this.escapeHtml(docUrl)}" target="_blank" class="manual-search-pill id dashboard-doc-link" title="Open in Paperless">${idPill}</a>`
+          : `<span class="manual-search-pill id">${idPill}</span>`;
+        return `
                 <div class="activity-item">
                     <div>
                         <div class="activity-item-title">${title}</div>
@@ -390,63 +458,75 @@ class DashboardStatsLoader {
                     </div>
                 </div>
             `;
-        }).join('');
+      })
+      .join('');
+  }
+
+  getPaperlessDocumentUrl(documentId) {
+    const docId = Number(documentId || 0);
+    if (
+      !Number.isInteger(docId) ||
+      docId <= 0 ||
+      !dashboardPaperlessPublicUrl
+    ) {
+      return '';
     }
 
-    getPaperlessDocumentUrl(documentId) {
-        const docId = Number(documentId || 0);
-        if (!Number.isInteger(docId) || docId <= 0 || !dashboardPaperlessPublicUrl) {
-            return '';
-        }
+    return `${dashboardPaperlessPublicUrl}/documents/${docId}/details`;
+  }
 
-        return `${dashboardPaperlessPublicUrl}/documents/${docId}/details`;
+  formatDateForPill(inputDate) {
+    if (!inputDate) {
+      return 'Unknown date';
     }
 
-    formatDateForPill(inputDate) {
-        if (!inputDate) {
-            return 'Unknown date';
-        }
-
-        const normalizedDate = String(inputDate).includes(' ')
-            ? String(inputDate).replace(' ', 'T')
-            : String(inputDate);
-        const parsed = new Date(normalizedDate);
-        if (Number.isNaN(parsed.getTime())) {
-            return 'Unknown date';
-        }
-
-        return parsed.toLocaleDateString('de-DE', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric'
-        });
+    const normalizedDate = String(inputDate).includes(' ')
+      ? String(inputDate).replace(' ', 'T')
+      : String(inputDate);
+    const parsed = new Date(normalizedDate);
+    if (Number.isNaN(parsed.getTime())) {
+      return 'Unknown date';
     }
 
-    escapeHtml(value) {
-        return String(value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
+    return parsed.toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  }
+
+  escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  renderLanguageDistribution(items) {
+    const container = document.getElementById('languageDistributionList');
+    if (!container) return;
+
+    const safeItems = Array.isArray(items) ? items : [];
+    if (safeItems.length === 0) {
+      container.innerHTML =
+        '<div class="language-row"><div class="language-name">No language data available.</div></div>';
+      return;
     }
 
-    renderLanguageDistribution(items) {
-        const container = document.getElementById('languageDistributionList');
-        if (!container) return;
-
-        const safeItems = Array.isArray(items) ? items : [];
-        if (safeItems.length === 0) {
-            container.innerHTML = '<div class="language-row"><div class="language-name">No language data available.</div></div>';
-            return;
-        }
-
-        const maxCount = Math.max(...safeItems.map((item) => Number(item.count || 0)), 1);
-        container.innerHTML = safeItems.map((item) => {
-            const name = String(item.language || 'Unknown').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            const count = Number(item.count || 0);
-            const width = Math.max(8, Math.round((count / maxCount) * 100));
-            return `
+    const maxCount = Math.max(
+      ...safeItems.map((item) => Number(item.count || 0)),
+      1
+    );
+    container.innerHTML = safeItems
+      .map((item) => {
+        const name = String(item.language || 'Unknown')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+        const count = Number(item.count || 0);
+        const width = Math.max(8, Math.round((count / maxCount) * 100));
+        return `
                 <div class="language-row">
                     <div class="language-head">
                         <span class="language-name">${name}</span>
@@ -457,339 +537,426 @@ class DashboardStatsLoader {
                     </div>
                 </div>
             `;
-        }).join('');
+      })
+      .join('');
+  }
+
+  formatRelativeDate(inputDate) {
+    if (!inputDate) {
+      return 'Unknown time';
     }
 
-    formatRelativeDate(inputDate) {
-        if (!inputDate) {
-            return 'Unknown time';
-        }
-
-        const normalizedDate = String(inputDate).includes(' ')
-            ? String(inputDate).replace(' ', 'T')
-            : String(inputDate);
-        const parsed = new Date(normalizedDate);
-        if (Number.isNaN(parsed.getTime())) {
-            return 'Unknown time';
-        }
-
-        const diffSeconds = Math.max(0, Math.floor((Date.now() - parsed.getTime()) / 1000));
-        if (diffSeconds < 60) return 'just now';
-        if (diffSeconds < 3600) {
-            const minutes = Math.floor(diffSeconds / 60);
-            return `${minutes}m ago`;
-        }
-        if (diffSeconds < 86400) {
-            const hours = Math.floor(diffSeconds / 3600);
-            return `${hours}h ago`;
-        }
-        const days = Math.floor(diffSeconds / 86400);
-        return `${days}d ago`;
+    const normalizedDate = String(inputDate).includes(' ')
+      ? String(inputDate).replace(' ', 'T')
+      : String(inputDate);
+    const parsed = new Date(normalizedDate);
+    if (Number.isNaN(parsed.getTime())) {
+      return 'Unknown time';
     }
 
-    updateCards(stats) {
-        const documentCount = stats.paperless_data.documentCount;
-        const processedCount = Math.max(0, Number(stats.paperless_data.processedDocumentCount || 0));
-        const ocrNeededCount = Math.max(0, stats.paperless_data.ocrNeededCount || 0);
-        const failedCount = Math.max(0, stats.paperless_data.failedCount || 0);
-        const queueBacklog = Math.max(0, stats.paperless_data.queueBacklog || 0);
-        const efficiencyRate = Math.max(0, Number(stats.paperless_data.processingEfficiencyRate || 0));
-        const failedRate = Math.max(0, Number(stats.paperless_data.failedRate || 0));
-        const processedToday = Math.max(0, Number(stats.paperless_data.processedToday || 0));
-        // Only the "Unprocessed" card needs processedCount capped to documentCount, so that
-        // an all-time processed total exceeding the current live scan-scope count can't push
-        // this figure negative. The headline processedCount above must stay uncapped.
-        const chartSafeProcessedCount = Math.min(processedCount, documentCount);
-        const unprocessedCount = Math.max(0, documentCount - chartSafeProcessedCount - ocrNeededCount - failedCount);
-
-        this.setText('processedCountValue', this.formatNumber(processedCount));
-        this.setText('ocrNeededCountValue', this.formatNumber(ocrNeededCount));
-        this.setText('failedCountValue', this.formatNumber(failedCount));
-        this.setText('unprocessedCountValue', this.formatNumber(unprocessedCount));
-        this.setText('totalDocumentsValue', this.formatNumber(documentCount));
-
-        this.setText('totalTagsValue', this.formatNumber(stats.paperless_data.tagCount));
-        this.setText('totalCorrespondentsValue', this.formatNumber(stats.paperless_data.correspondentCount));
-
-        this.setText('avgPromptTokensValue', this.formatNumber(stats.openai_data.averagePromptTokens, { compact: true }));
-        this.setText('avgCompletionTokensValue', this.formatNumber(stats.openai_data.averageCompletionTokens, { compact: true }));
-        this.setText('avgTotalTokensValue', this.formatNumber(stats.openai_data.averageTotalTokens, { compact: true }));
-        this.setText('tokensOverallValue', this.formatNumber(stats.openai_data.tokensOverall, { compact: true }));
-        this.setText('documentsProcessedValue', this.formatNumber(processedCount));
-
-        this.setText('efficiencyRateValue', `${efficiencyRate}%`);
-        this.setText('queueBacklogValue', this.formatNumber(queueBacklog));
-        this.setText('failedRateValue', `${failedRate}%`);
-        this.setText('processedTodayValue', this.formatNumber(processedToday));
-
-        this.renderRecentActivity(stats.paperless_data.recentActivity);
-        this.renderLanguageDistribution(stats.paperless_data.languageDistribution);
+    const diffSeconds = Math.max(
+      0,
+      Math.floor((Date.now() - parsed.getTime()) / 1000)
+    );
+    if (diffSeconds < 60) return 'just now';
+    if (diffSeconds < 3600) {
+      const minutes = Math.floor(diffSeconds / 60);
+      return `${minutes}m ago`;
     }
-
-    async load() {
-        const loadingStartedAt = Date.now();
-        this.setLoadingState(true);
-        this.setLoadingProgress(15, 'Loading dashboard data...', 'Fetching latest statistics from API.', { keepIndeterminate: true });
-        const fallbackStats = this.getFallbackStats();
-        try {
-            const abortController = new AbortController();
-            const timeoutId = setTimeout(() => abortController.abort(), this.requestTimeoutMs);
-
-            const response = await fetch('/api/dashboard/stats', {
-                signal: abortController.signal
-            });
-            clearTimeout(timeoutId);
-
-            if (!response.ok) {
-                throw new Error('Failed to load dashboard stats');
-            }
-
-            const payload = await response.json();
-            if (!payload?.success) {
-                throw new Error(payload?.error || 'Invalid dashboard stats response');
-            }
-
-            this.setLoadingProgress(58, 'Applying statistics...', 'Updating cards and activity feeds.');
-
-            window.dashboardData = {
-                documentCount: payload.paperless_data.documentCount,
-                processedCount: payload.paperless_data.processedDocumentCount,
-                ocrNeededCount: payload.paperless_data.ocrNeededCount,
-                failedCount: payload.paperless_data.failedCount,
-                tokenDistribution: payload.paperless_data.tokenDistribution,
-                documentTypes: payload.paperless_data.documentTypes,
-                tokenTrend: payload.paperless_data.tokenTrend,
-                recentActivity: payload.paperless_data.recentActivity,
-                languageDistribution: payload.paperless_data.languageDistribution,
-                queueBacklog: payload.paperless_data.queueBacklog,
-                processingEfficiencyRate: payload.paperless_data.processingEfficiencyRate,
-                failedRate: payload.paperless_data.failedRate,
-                processedToday: payload.paperless_data.processedToday
-            };
-
-            this.updateCards(payload);
-            this.setLoadingProgress(82, 'Rendering visualizations...', 'Drawing charts and trend graphs.');
-            this.updateCharts(payload);
-            this.setLoadingProgress(96, 'Finishing up...', 'Finalizing dashboard layout.');
-        } catch (error) {
-            console.error('Error loading dashboard stats:', error);
-
-            this.setLoadingProgress(60, 'Using fallback data...', 'Dashboard remains usable while stats API is unavailable.');
-            this.updateCards(fallbackStats);
-            this.updateCharts(fallbackStats);
-        } finally {
-            const elapsedMs = Date.now() - loadingStartedAt;
-            if (elapsedMs < this.minimumLoadingTimeMs) {
-                await new Promise(resolve => setTimeout(resolve, this.minimumLoadingTimeMs - elapsedMs));
-            }
-            this.setLoadingProgress(100, 'Dashboard ready', 'Live updates will continue in the background.');
-            this.setLoadingState(false);
-        }
+    if (diffSeconds < 86400) {
+      const hours = Math.floor(diffSeconds / 3600);
+      return `${hours}h ago`;
     }
+    const days = Math.floor(diffSeconds / 86400);
+    return `${days}d ago`;
+  }
 
-    // Silent background refresh used for live updates (e.g. a document just finished
-    // processing). Unlike load(), this never toggles the loading skeletons, so the
-    // cards and activity list update in place without flickering.
-    async refresh() {
-        if (this.refreshInFlight) return;
-        this.refreshInFlight = true;
+  updateCards(stats) {
+    const documentCount = stats.paperless_data.documentCount;
+    const processedCount = Math.max(
+      0,
+      Number(stats.paperless_data.processedDocumentCount || 0)
+    );
+    const ocrNeededCount = Math.max(
+      0,
+      stats.paperless_data.ocrNeededCount || 0
+    );
+    const failedCount = Math.max(0, stats.paperless_data.failedCount || 0);
+    const queueBacklog = Math.max(0, stats.paperless_data.queueBacklog || 0);
+    const efficiencyRate = Math.max(
+      0,
+      Number(stats.paperless_data.processingEfficiencyRate || 0)
+    );
+    const failedRate = Math.max(
+      0,
+      Number(stats.paperless_data.failedRate || 0)
+    );
+    const processedToday = Math.max(
+      0,
+      Number(stats.paperless_data.processedToday || 0)
+    );
+    // Only the "Unprocessed" card needs processedCount capped to documentCount, so that
+    // an all-time processed total exceeding the current live scan-scope count can't push
+    // this figure negative. The headline processedCount above must stay uncapped.
+    const chartSafeProcessedCount = Math.min(processedCount, documentCount);
+    const unprocessedCount = Math.max(
+      0,
+      documentCount - chartSafeProcessedCount - ocrNeededCount - failedCount
+    );
 
-        try {
-            const abortController = new AbortController();
-            const timeoutId = setTimeout(() => abortController.abort(), this.requestTimeoutMs);
+    this.setText('processedCountValue', this.formatNumber(processedCount));
+    this.setText('ocrNeededCountValue', this.formatNumber(ocrNeededCount));
+    this.setText('failedCountValue', this.formatNumber(failedCount));
+    this.setText('unprocessedCountValue', this.formatNumber(unprocessedCount));
+    this.setText('totalDocumentsValue', this.formatNumber(documentCount));
 
-            const response = await fetch('/api/dashboard/stats', {
-                signal: abortController.signal
-            });
-            clearTimeout(timeoutId);
+    this.setText(
+      'totalTagsValue',
+      this.formatNumber(stats.paperless_data.tagCount)
+    );
+    this.setText(
+      'totalCorrespondentsValue',
+      this.formatNumber(stats.paperless_data.correspondentCount)
+    );
 
-            if (!response.ok) {
-                throw new Error('Failed to refresh dashboard stats');
-            }
+    this.setText(
+      'avgPromptTokensValue',
+      this.formatNumber(stats.openai_data.averagePromptTokens, {
+        compact: true,
+      })
+    );
+    this.setText(
+      'avgCompletionTokensValue',
+      this.formatNumber(stats.openai_data.averageCompletionTokens, {
+        compact: true,
+      })
+    );
+    this.setText(
+      'avgTotalTokensValue',
+      this.formatNumber(stats.openai_data.averageTotalTokens, { compact: true })
+    );
+    this.setText(
+      'tokensOverallValue',
+      this.formatNumber(stats.openai_data.tokensOverall, { compact: true })
+    );
+    this.setText('documentsProcessedValue', this.formatNumber(processedCount));
 
-            const payload = await response.json();
-            if (!payload?.success) {
-                throw new Error(payload?.error || 'Invalid dashboard stats response');
-            }
+    this.setText('efficiencyRateValue', `${efficiencyRate}%`);
+    this.setText('queueBacklogValue', this.formatNumber(queueBacklog));
+    this.setText('failedRateValue', `${failedRate}%`);
+    this.setText('processedTodayValue', this.formatNumber(processedToday));
 
-            window.dashboardData = {
-                documentCount: payload.paperless_data.documentCount,
-                processedCount: payload.paperless_data.processedDocumentCount,
-                ocrNeededCount: payload.paperless_data.ocrNeededCount,
-                failedCount: payload.paperless_data.failedCount,
-                tokenDistribution: payload.paperless_data.tokenDistribution,
-                documentTypes: payload.paperless_data.documentTypes,
-                tokenTrend: payload.paperless_data.tokenTrend,
-                recentActivity: payload.paperless_data.recentActivity,
-                languageDistribution: payload.paperless_data.languageDistribution,
-                queueBacklog: payload.paperless_data.queueBacklog,
-                processingEfficiencyRate: payload.paperless_data.processingEfficiencyRate,
-                failedRate: payload.paperless_data.failedRate,
-                processedToday: payload.paperless_data.processedToday
-            };
+    this.renderRecentActivity(stats.paperless_data.recentActivity);
+    this.renderLanguageDistribution(stats.paperless_data.languageDistribution);
+  }
 
-            this.updateCards(payload);
-            this.updateCharts(payload);
-        } catch (error) {
-            console.error('Error refreshing dashboard stats:', error);
-        } finally {
-            this.refreshInFlight = false;
-        }
+  async load() {
+    const loadingStartedAt = Date.now();
+    this.setLoadingState(true);
+    this.setLoadingProgress(
+      15,
+      'Loading dashboard data...',
+      'Fetching latest statistics from API.',
+      { keepIndeterminate: true }
+    );
+    const fallbackStats = this.getFallbackStats();
+    try {
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(
+        () => abortController.abort(),
+        this.requestTimeoutMs
+      );
+
+      const response = await fetch('/api/dashboard/stats', {
+        signal: abortController.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error('Failed to load dashboard stats');
+      }
+
+      const payload = await response.json();
+      if (!payload?.success) {
+        throw new Error(payload?.error || 'Invalid dashboard stats response');
+      }
+
+      this.setLoadingProgress(
+        58,
+        'Applying statistics...',
+        'Updating cards and activity feeds.'
+      );
+
+      window.dashboardData = {
+        documentCount: payload.paperless_data.documentCount,
+        processedCount: payload.paperless_data.processedDocumentCount,
+        ocrNeededCount: payload.paperless_data.ocrNeededCount,
+        failedCount: payload.paperless_data.failedCount,
+        tokenDistribution: payload.paperless_data.tokenDistribution,
+        documentTypes: payload.paperless_data.documentTypes,
+        tokenTrend: payload.paperless_data.tokenTrend,
+        recentActivity: payload.paperless_data.recentActivity,
+        languageDistribution: payload.paperless_data.languageDistribution,
+        queueBacklog: payload.paperless_data.queueBacklog,
+        processingEfficiencyRate:
+          payload.paperless_data.processingEfficiencyRate,
+        failedRate: payload.paperless_data.failedRate,
+        processedToday: payload.paperless_data.processedToday,
+      };
+
+      this.updateCards(payload);
+      this.setLoadingProgress(
+        82,
+        'Rendering visualizations...',
+        'Drawing charts and trend graphs.'
+      );
+      this.updateCharts(payload);
+      this.setLoadingProgress(
+        96,
+        'Finishing up...',
+        'Finalizing dashboard layout.'
+      );
+    } catch (error) {
+      console.error('Error loading dashboard stats:', error);
+
+      this.setLoadingProgress(
+        60,
+        'Using fallback data...',
+        'Dashboard remains usable while stats API is unavailable.'
+      );
+      this.updateCards(fallbackStats);
+      this.updateCharts(fallbackStats);
+    } finally {
+      const elapsedMs = Date.now() - loadingStartedAt;
+      if (elapsedMs < this.minimumLoadingTimeMs) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, this.minimumLoadingTimeMs - elapsedMs)
+        );
+      }
+      this.setLoadingProgress(
+        100,
+        'Dashboard ready',
+        'Live updates will continue in the background.'
+      );
+      this.setLoadingState(false);
     }
+  }
+
+  // Silent background refresh used for live updates (e.g. a document just finished
+  // processing). Unlike load(), this never toggles the loading skeletons, so the
+  // cards and activity list update in place without flickering.
+  async refresh() {
+    if (this.refreshInFlight) return;
+    this.refreshInFlight = true;
+
+    try {
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(
+        () => abortController.abort(),
+        this.requestTimeoutMs
+      );
+
+      const response = await fetch('/api/dashboard/stats', {
+        signal: abortController.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error('Failed to refresh dashboard stats');
+      }
+
+      const payload = await response.json();
+      if (!payload?.success) {
+        throw new Error(payload?.error || 'Invalid dashboard stats response');
+      }
+
+      window.dashboardData = {
+        documentCount: payload.paperless_data.documentCount,
+        processedCount: payload.paperless_data.processedDocumentCount,
+        ocrNeededCount: payload.paperless_data.ocrNeededCount,
+        failedCount: payload.paperless_data.failedCount,
+        tokenDistribution: payload.paperless_data.tokenDistribution,
+        documentTypes: payload.paperless_data.documentTypes,
+        tokenTrend: payload.paperless_data.tokenTrend,
+        recentActivity: payload.paperless_data.recentActivity,
+        languageDistribution: payload.paperless_data.languageDistribution,
+        queueBacklog: payload.paperless_data.queueBacklog,
+        processingEfficiencyRate:
+          payload.paperless_data.processingEfficiencyRate,
+        failedRate: payload.paperless_data.failedRate,
+        processedToday: payload.paperless_data.processedToday,
+      };
+
+      this.updateCards(payload);
+      this.updateCharts(payload);
+    } catch (error) {
+      console.error('Error refreshing dashboard stats:', error);
+    } finally {
+      this.refreshInFlight = false;
+    }
+  }
 }
 
 // Modal Management
 class ModalManager {
-    constructor() {
-        this.modal = document.getElementById('detailsModal');
-        this.modalTitle = this.modal.querySelector('.modal-title');
-        this.modalContent = this.modal.querySelector('.modal-data');
-        this.modalLoader = this.modal.querySelector('.modal-loader');
-        this.initializeEventListeners();
-    }
+  constructor() {
+    this.modal = document.getElementById('detailsModal');
+    this.modalTitle = this.modal.querySelector('.modal-title');
+    this.modalContent = this.modal.querySelector('.modal-data');
+    this.modalLoader = this.modal.querySelector('.modal-loader');
+    this.initializeEventListeners();
+  }
 
-    initializeEventListeners() {
-        // Close button click
-        this.modal.querySelector('.modal-close').addEventListener('click', () => this.hideModal());
-        
-        // Overlay click
-        this.modal.querySelector('.modal-overlay').addEventListener('click', () => this.hideModal());
-        
-        // Escape key press
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape' && this.modal.classList.contains('show')) {
-                this.hideModal();
-            }
-        });
-    }
+  initializeEventListeners() {
+    // Close button click
+    this.modal
+      .querySelector('.modal-close')
+      .addEventListener('click', () => this.hideModal());
 
-    showModal(title) {
-        this.modalTitle.textContent = title;
-        this.modalContent.innerHTML = '';
-        this.modal.classList.remove('hidden'); // Fix: Remove 'hidden' class
-        this.modal.classList.add('show');
-        document.body.style.overflow = 'hidden';
-    }
+    // Overlay click
+    this.modal
+      .querySelector('.modal-overlay')
+      .addEventListener('click', () => this.hideModal());
 
-    hideModal() {
-        this.modal.classList.remove('show');
-        this.modal.classList.add('hidden'); // Fix: Add 'hidden' class back
-        document.body.style.overflow = '';
-    }
+    // Escape key press
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this.modal.classList.contains('show')) {
+        this.hideModal();
+      }
+    });
+  }
 
-    showLoader() {
-        this.modalLoader.classList.remove('hidden');
-        this.modalContent.classList.add('hidden');
-    }
+  showModal(title) {
+    this.modalTitle.textContent = title;
+    this.modalContent.innerHTML = '';
+    this.modal.classList.remove('hidden'); // Fix: Remove 'hidden' class
+    this.modal.classList.add('show');
+    document.body.style.overflow = 'hidden';
+  }
 
-    hideLoader() {
-        this.modalLoader.classList.add('hidden');
-        this.modalContent.classList.remove('hidden');
-    }
+  hideModal() {
+    this.modal.classList.remove('show');
+    this.modal.classList.add('hidden'); // Fix: Add 'hidden' class back
+    document.body.style.overflow = '';
+  }
 
-    setContent(content) {
-        this.modalContent.innerHTML = content;
-    }
+  showLoader() {
+    this.modalLoader.classList.remove('hidden');
+    this.modalContent.classList.add('hidden');
+  }
+
+  hideLoader() {
+    this.modalLoader.classList.add('hidden');
+    this.modalContent.classList.remove('hidden');
+  }
+
+  setContent(content) {
+    this.modalContent.innerHTML = content;
+  }
 }
 
 // Make showTagDetails and showCorrespondentDetails globally available
-window.showTagDetails = async function() {
-    window.modalManager.showModal('Tag Overview');
-    window.modalManager.showLoader();
+window.showTagDetails = async function () {
+  window.modalManager.showModal('Tag Overview');
+  window.modalManager.showLoader();
 
-    try {
-        const response = await fetch('/api/tagsCount');
-        const tags = await response.json();
+  try {
+    const response = await fetch('/api/tagsCount');
+    const tags = await response.json();
 
-        let content = '<div class="detail-list">';
-        tags.forEach(tag => {
-            content += `
+    let content = '<div class="detail-list">';
+    tags.forEach((tag) => {
+      content += `
                 <div class="detail-item">
                     <span class="detail-item-name">${escapeHtml(tag.name)}</span>
                     <span class="detail-item-info">${tag.document_count || 0} documents</span>
                 </div>
             `;
-        });
-        content += '</div>';
+    });
+    content += '</div>';
 
-        window.modalManager.setContent(content);
-    } catch (error) {
-        console.error('Error loading tags:', error);
-        window.modalManager.setContent('<div class="text-red-500 p-4">Error loading tags. Please try again later.</div>');
-    } finally {
-        window.modalManager.hideLoader();
-    }
-}
+    window.modalManager.setContent(content);
+  } catch (error) {
+    console.error('Error loading tags:', error);
+    window.modalManager.setContent(
+      '<div class="text-red-500 p-4">Error loading tags. Please try again later.</div>'
+    );
+  } finally {
+    window.modalManager.hideLoader();
+  }
+};
 
-window.showCorrespondentDetails = async function() {
-    window.modalManager.showModal('Correspondent Overview');
-    window.modalManager.showLoader();
+window.showCorrespondentDetails = async function () {
+  window.modalManager.showModal('Correspondent Overview');
+  window.modalManager.showLoader();
 
-    try {
-        const response = await fetch('/api/correspondentsCount');
-        const correspondents = await response.json();
+  try {
+    const response = await fetch('/api/correspondentsCount');
+    const correspondents = await response.json();
 
-        let content = '<div class="detail-list">';
-        correspondents.forEach(correspondent => {
-            content += `
+    let content = '<div class="detail-list">';
+    correspondents.forEach((correspondent) => {
+      content += `
                 <div class="detail-item">
                     <span class="detail-item-name">${escapeHtml(correspondent.name)}</span>
                     <span class="detail-item-info">${correspondent.document_count || 0} documents</span>
                 </div>
             `;
-        });
-        content += '</div>';
+    });
+    content += '</div>';
 
-        window.modalManager.setContent(content);
-    } catch (error) {
-        console.error('Error loading correspondents:', error);
-        window.modalManager.setContent('<div class="text-red-500 p-4">Error loading correspondents. Please try again later.</div>');
-    } finally {
-        window.modalManager.hideLoader();
-    }
-}
+    window.modalManager.setContent(content);
+  } catch (error) {
+    console.error('Error loading correspondents:', error);
+    window.modalManager.setContent(
+      '<div class="text-red-500 p-4">Error loading correspondents. Please try again later.</div>'
+    );
+  } finally {
+    window.modalManager.hideLoader();
+  }
+};
 
 // Navigation Management
 class NavigationManager {
-    constructor() {
-        this.sidebarLinks = document.querySelectorAll('.sidebar-link');
-        this.initialize();
-    }
+  constructor() {
+    this.sidebarLinks = document.querySelectorAll('.sidebar-link');
+    this.initialize();
+  }
 
-    initialize() {
-        this.sidebarLinks.forEach(link => {
-            link.addEventListener('click', (e) => {
-                // Prevent default only for placeholder links.
-                if (link.getAttribute('href') === '#') {
-                    e.preventDefault();
-                }
-                this.setActiveLink(link);
-            });
-        });
-    }
+  initialize() {
+    this.sidebarLinks.forEach((link) => {
+      link.addEventListener('click', (e) => {
+        // Prevent default only for placeholder links.
+        if (link.getAttribute('href') === '#') {
+          e.preventDefault();
+        }
+        this.setActiveLink(link);
+      });
+    });
+  }
 
-    setActiveLink(activeLink) {
-        this.sidebarLinks.forEach(link => {
-            link.classList.remove('active');
-        });
-        activeLink.classList.add('active');
-    }
+  setActiveLink(activeLink) {
+    this.sidebarLinks.forEach((link) => {
+      link.classList.remove('active');
+    });
+    activeLink.classList.add('active');
+  }
 }
 
 // Initialize everything when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
-    window.navigationManager = new NavigationManager();
+  window.navigationManager = new NavigationManager();
 
-    if (document.getElementById('documentChart')) {
-        window.chartManager = new ChartManager();
-    }
+  if (document.getElementById('documentChart')) {
+    window.chartManager = new ChartManager();
+  }
 
-    if (document.getElementById('detailsModal')) {
-        window.modalManager = new ModalManager();
-    }
+  if (document.getElementById('detailsModal')) {
+    window.modalManager = new ModalManager();
+  }
 
-    if (document.getElementById('dashboardDataPayload')) {
-        window.dashboardStatsLoader = new DashboardStatsLoader();
-        window.dashboardStatsLoader.load();
-    }
+  if (document.getElementById('dashboardDataPayload')) {
+    window.dashboardStatsLoader = new DashboardStatsLoader();
+    window.dashboardStatsLoader.load();
+  }
 });

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -6184,10 +6184,7 @@ router.get('/api/dashboard/stats', async (req, res) => {
       documentModel.getCurrentProcessingStatus(),
     ]);
 
-    const processedDocumentCount = Math.min(
-      rawProcessedDocumentCount,
-      documentCount
-    );
+    const processedDocumentCount = rawProcessedDocumentCount;
     const failedCount = ocrFailedCount + processingFailedCount;
     const queueBacklog = Math.max(0, ocrNeededCount + failedCount);
     const processingAttemptCount = processedDocumentCount + failedCount;

--- a/views/partials/scripts/dashboard-scripts.ejs
+++ b/views/partials/scripts/dashboard-scripts.ejs
@@ -373,12 +373,20 @@
         }
     }
 
+    let lastSeenProcessedDocId = null;
+
     function updateProcessingStatus() {
         fetch('/api/processing-status')
             .then(response => response.json())
             .then(data => {
                 console.log('Processing status data:', data);
-                
+
+                const currentProcessedDocId = data.lastProcessed ? data.lastProcessed.documentId : null;
+                if (lastSeenProcessedDocId !== null && currentProcessedDocId !== null && currentProcessedDocId !== lastSeenProcessedDocId) {
+                    window.dashboardStatsLoader?.refresh();
+                }
+                lastSeenProcessedDocId = currentProcessedDocId;
+
                 const processingContainer = document.getElementById('processingContainer');
                 const idleContainer = document.getElementById('idleContainer');
                 const isScanning = Boolean(data.isScanning || data.currentlyProcessing);


### PR DESCRIPTION
## Summary
- Fix dashboard "Unprocessed" card math so an all-time processed count that exceeds the live scan-scope document count can no longer push it negative, while keeping the headline processed count uncapped
- Add silent background dashboard refresh (`DashboardStatsLoader.refresh()`) triggered when `/api/processing-status` reports a newly completed document, so cards/activity update in place without a full reload or loading-skeleton flicker
- Trim the corresponding changelog bullets in the v2026.07.03 entries to drop internal env var names from user-facing text
- Clarify in the README that local vision OCR isn't limited to a couple of named models — any vision-capable model served by Ollama or an OpenAI-compatible endpoint works (with examples), that Quickstart auto-detects vision models, and that multi-page PDF rendering applies to local vision providers while Mistral OCR handles PDFs natively

## Test plan
- [x] `node scripts/run-tests.js --all` (pre-existing suite, unaffected by these changes)
- [x] Manually verify the dashboard "Unprocessed" card no longer goes negative when the all-time processed count exceeds the current document count
- [x] Manually verify dashboard cards update live (no skeleton flash) after a document finishes processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)