### PR TITLE
fix: resolve AI response/prompt log paths relative to process.cwd()

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -38,6 +38,7 @@ const TESTS = {
   'injected-env-priority': 'test-injected-env-priority.js',
   'log-level-config': 'test-log-level-config.js',
   'log-level-logger': 'test-log-level-logger.js',
+  'native-install-log-paths': 'test-native-install-log-paths.js',
   'login-mfa-flow': 'test-login-mfa-flow.js',
   'ocr-fallback-ai-errors': 'test-ocr-fallback-ai-errors.js',
   'ocr-startup-recovery': 'test-ocr-startup-recovery.js',
@@ -102,7 +103,11 @@ const AREAS = {
     'setup-ocr-disabled-skip',
     'setupservice-ocr-validation',
   ],
-  observability: ['log-level-config', 'log-level-logger'],
+  observability: [
+    'log-level-config',
+    'log-level-logger',
+    'native-install-log-paths',
+  ],
   processing: [
     'document-type-restriction',
     'ignore-tags-filter',

--- a/services/azureService.js
+++ b/services/azureService.js
@@ -14,7 +14,7 @@ const fs = require('fs').promises;
 const path = require('path');
 const { THUMBNAIL_CACHE_DIR, getThumbnailCachePath } = require('./thumbnailCachePaths');
 const RestrictionPromptService = require('./restrictionPromptService');
-const responseLogPath = path.join('/app', 'data', 'logs', 'response.txt');
+const responseLogPath = path.join(process.cwd(), 'data', 'logs', 'response.txt');
 
 class AzureOpenAIService {
   constructor() {

--- a/services/customService.js
+++ b/services/customService.js
@@ -15,7 +15,7 @@ const fs = require('fs').promises;
 const path = require('path');
 const { THUMBNAIL_CACHE_DIR, getThumbnailCachePath } = require('./thumbnailCachePaths');
 const RestrictionPromptService = require('./restrictionPromptService');
-const responseLogPath = path.join('/app', 'data', 'logs', 'response.txt');
+const responseLogPath = path.join(process.cwd(), 'data', 'logs', 'response.txt');
 const CUSTOM_PROVIDER_FALLBACK_API_KEY = 'no-auth-required';
 
 class CustomOpenAIService {

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -13,7 +13,7 @@ const path = require('path');
 const { THUMBNAIL_CACHE_DIR, getThumbnailCachePath } = require('./thumbnailCachePaths');
 const { model } = require('./ollamaService');
 const RestrictionPromptService = require('./restrictionPromptService');
-const responseLogPath = path.join('/app', 'data', 'logs', 'response.txt');
+const responseLogPath = path.join(process.cwd(), 'data', 'logs', 'response.txt');
 
 class OpenAIService {
   constructor() {

--- a/services/serviceUtils.js
+++ b/services/serviceUtils.js
@@ -163,7 +163,7 @@ async function truncateToTokenLimit(text, maxTokens, model = process.env.OPENAI_
 }
 
 // Write prompt and content to a file with size management
-async function writePromptToFile(systemPrompt, truncatedContent, filePath = '/app/data/logs/prompt.txt', maxSize = 10 * 1024 * 1024) {
+async function writePromptToFile(systemPrompt, truncatedContent, filePath = path.join(process.cwd(), 'data', 'logs', 'prompt.txt'), maxSize = 10 * 1024 * 1024) {
     try {
         // Ensure the logs directory exists
         await fs.mkdir(path.dirname(filePath), { recursive: true });

--- a/tests/test-native-install-log-paths.js
+++ b/tests/test-native-install-log-paths.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+
+function assertIncludes(content, snippet, message) {
+  if (!content.includes(snippet)) {
+    throw new Error(message);
+  }
+}
+
+function assertNotIncludes(content, snippet, message) {
+  if (content.includes(snippet)) {
+    throw new Error(message);
+  }
+}
+
+function run() {
+  console.log('\n=== Native Install Log Path Checks ===');
+
+  const filesUsingResponseLogPath = [
+    'services/openaiService.js',
+    'services/customService.js',
+    'services/azureService.js',
+  ];
+
+  filesUsingResponseLogPath.forEach((relativePath) => {
+    const fullPath = path.join(process.cwd(), relativePath);
+    const content = fs.readFileSync(fullPath, 'utf8');
+
+    assertNotIncludes(
+      content,
+      "path.join('/app'",
+      `${relativePath} must not hardcode the Docker '/app' path for AI response logging`
+    );
+    assertIncludes(
+      content,
+      'path.join(process.cwd()',
+      `${relativePath} must resolve the AI response log path relative to process.cwd()`
+    );
+  });
+
+  const serviceUtilsPath = path.join(
+    process.cwd(),
+    'services',
+    'serviceUtils.js'
+  );
+  const serviceUtilsContent = fs.readFileSync(serviceUtilsPath, 'utf8');
+
+  assertNotIncludes(
+    serviceUtilsContent,
+    "'/app/data/logs/prompt.txt'",
+    "serviceUtils.js's writePromptToFile() must not default to a hardcoded '/app' path"
+  );
+  assertIncludes(
+    serviceUtilsContent,
+    "path.join(process.cwd(), 'data', 'logs', 'prompt.txt')",
+    "serviceUtils.js's writePromptToFile() must default to a process.cwd()-relative prompt log path"
+  );
+
+  console.log('✅ All native install log path checks passed');
+}
+
+run();
+console.log('✅ test-native-install-log-paths passed');


### PR DESCRIPTION
## Summary
- `services/openaiService.js`, `customService.js`, and `azureService.js` each hardcode `path.join('/app', 'data', 'logs', 'response.txt')` for AI response logging, and `services/serviceUtils.js`'s `writePromptToFile()` defaults its `filePath` parameter to the literal `'/app/data/logs/prompt.txt'`.
- These paths only exist inside the Docker image (`Dockerfile.base` sets `WORKDIR /app`). On a native/bare-metal install (explicitly documented as supported in the README — e.g. a systemd service or LXC container running from `/opt/paperless-ai-next`), `process.cwd()` is the app directory, not `/app`, so `fs.mkdir('/app', ...)` fails with `ENOENT` on every single document processed. The error is caught, so processing still completes, but `response.txt`/`prompt.txt` are silently never written and the journal fills up with the repeated warning.
- Fix: replaced the hardcoded `/app` segment with `process.cwd()` in all four locations, matching how `config/config.js` and `models/document.js` already resolve `data/` paths. Docker behavior (`WORKDIR /app`) is unchanged.

## Test plan
- [x] Added `tests/test-native-install-log-paths.js`: a static source-text check (no app boot required, same convention as `tests/test-history-xss-hardening.js`) asserting none of the four files hardcode `/app` for these log paths. Registered in `scripts/run-tests.js` (`observability` area).
- [x] `node scripts/run-tests.js --all`: 43 passed, 7 skipped (server-dependent tests), 0 failed.
- [x] `npx eslint`/`prettier` clean on the new test file and `scripts/run-tests.js`.
- [x] `node scripts/regen-openapi.js` produces no diff (no API surface change).
- [ ] `openaiService.js`, `customService.js`, and `azureService.js` already fail `npx eslint` with 16 pre-existing errors unrelated to this change (unused imports/vars, and a `preserve-caught-error` rule about missing `cause` on rethrown errors) — confirmed present on `origin/main` before this commit. Left untouched here since fixing the `cause`-chain violations means touching real error-handling logic across all three files, well outside this fix's scope (confirmed with the repo maintainer); a separate cleanup PR is a better fit.

Closes #237


---
_Generated by [Claude Code](https://claude.ai/code/session_0157iEcJwymtoB8fgX429hBj)_