### PR TITLE
fix: stop gating Quickstart's OCR model dropdown on the vision heuristic

### DIFF
--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -1,3 +1,4 @@
+/* global Swal */
 class SetupWizard {
     constructor() {
         this.bootstrap = window.__SETUP_BOOTSTRAP__ || {};
@@ -979,7 +980,14 @@ class SetupWizard {
             this.quickstartState.detection = detection;
 
             const textModels = Array.isArray(detection.textModels) ? detection.textModels : [];
-            const visionModels = Array.isArray(detection.visionModels) ? detection.visionModels : [];
+            // Every detected model that isn't embedding-only is a valid OCR
+            // candidate (textModels already excludes embedding-only models -
+            // see quickstartService.classifyModelName). Rather than also
+            // gating on the vision name-heuristic (which can miss real
+            // OCR-capable models with unfamiliar names, e.g. dedicated OCR
+            // models), offer the full list here and let the user pick; a
+            // heuristic "suggested" default is still pre-selected below.
+            const ocrCandidateModels = textModels;
 
             this.setModelSelectOptions(this.quickstartAiModel, textModels, textModels.length > 0 ? 'Select AI model' : 'No text-capable models found');
             this.quickstartAiModel.disabled = textModels.length === 0;
@@ -987,20 +995,20 @@ class SetupWizard {
                 this.quickstartAiModel.value = detection.suggestedAiModel;
             }
 
-            this.setModelSelectOptions(this.quickstartOcrModel, visionModels, visionModels.length > 0 ? 'Select OCR model' : 'No vision-capable models found');
-            this.quickstartOcrModel.disabled = visionModels.length === 0;
+            this.setModelSelectOptions(this.quickstartOcrModel, ocrCandidateModels, ocrCandidateModels.length > 0 ? 'Select OCR model' : 'No models found');
+            this.quickstartOcrModel.disabled = ocrCandidateModels.length === 0;
             if (detection.suggestedOcrModel) {
                 this.quickstartOcrModel.value = detection.suggestedOcrModel;
             }
 
-            const hasVisionModels = visionModels.length > 0;
-            this.quickstartEnableOcr.disabled = !hasVisionModels;
-            this.quickstartEnableOcr.checked = hasVisionModels;
+            const hasOcrCandidateModels = ocrCandidateModels.length > 0;
+            this.quickstartEnableOcr.disabled = !hasOcrCandidateModels;
+            this.quickstartEnableOcr.checked = hasOcrCandidateModels;
             if (this.quickstartOcrHint) {
-                this.quickstartOcrHint.classList.toggle('hidden', hasVisionModels);
-                this.quickstartOcrHint.textContent = hasVisionModels
+                this.quickstartOcrHint.classList.toggle('hidden', hasOcrCandidateModels);
+                this.quickstartOcrHint.textContent = hasOcrCandidateModels
                     ? ''
-                    : 'No vision-capable model found — OCR fallback stays disabled.';
+                    : 'No models found — OCR fallback stays disabled.';
             }
 
             if (this.quickstartHint) {
@@ -1066,7 +1074,7 @@ class SetupWizard {
 
         if (enableOcr && selectedOcrModel) {
             this.mistralOcrEnabled.value = 'yes';
-            this.ocrProvider.value = 'custom';
+            this.ocrProvider.value = detection.ocrProvider || 'custom';
             this.ocrApiUrl.value = detection.resolvedOcrApiUrl || '';
             this.ocrApiKey.value = quickstartKey;
             this.setModelSelectOptions(this.mistralOcrModel, [selectedOcrModel], 'Select OCR model');
@@ -1665,7 +1673,7 @@ class SetupWizard {
         try {
             await navigator.clipboard.writeText(this.envPreview.value);
             await this.showPopup({ icon: 'success', title: 'Copied', text: 'Environment keys copied to clipboard.' });
-        } catch (_error) {
+        } catch {
             this.envPreview.select();
             document.execCommand('copy');
             await this.showPopup({ icon: 'success', title: 'Copied', text: 'Environment keys copied to clipboard.' });
@@ -1707,7 +1715,6 @@ class SetupWizard {
     async finalizeSetup(options = {}) {
         const validations = [];
         for (let index = 0; index <= 5; index += 1) {
-            // eslint-disable-next-line no-await-in-loop
             const valid = await this.validateStepBeforeContinue(index);
             if (!valid) {
                 validations.push(index);

--- a/services/quickstartService.js
+++ b/services/quickstartService.js
@@ -181,6 +181,17 @@ class QuickstartService {
     return headers;
   }
 
+  // Which OCR provider to default the wizard to. This is deliberately not a
+  // per-model capability guess (those can miss real OCR-capable models with
+  // unfamiliar names); it only checks the one endpoint this codebase already
+  // knows has a dedicated /ocr path (see
+  // setupService.getMistralUrlValidationOptions). The "OCR fallback" wizard
+  // step always lets the user override this before finishing setup.
+  resolveOcrProviderDefault(bareBaseUrl) {
+    const normalized = String(bareBaseUrl || '').trim().toLowerCase();
+    return normalized.includes('api.mistral.ai') ? 'mistral' : 'custom';
+  }
+
   buildLoopbackBlockedError(validationError) {
     return new Error(
       `URL validation failed: ${validationError} — localhost URLs are blocked by default. `
@@ -371,9 +382,7 @@ class QuickstartService {
       flavor: probeResult.flavor,
       aiProvider: isOllama ? 'ollama' : 'custom',
       resolvedAiApiUrl: isOllama ? urls.bareBaseUrl : urls.versionedBaseUrl,
-      // The wizard/settings OCR provider is always "custom" for local
-      // endpoints (the backend aliases custom -> ollama internally).
-      ocrProvider: 'custom',
+      ocrProvider: this.resolveOcrProviderDefault(urls.bareBaseUrl),
       resolvedOcrApiUrl: isOllama ? urls.bareBaseUrl : urls.versionedBaseUrl,
       models: models.map((m) => ({
         id: m.id,

--- a/tests/test-quickstart-model-classification.js
+++ b/tests/test-quickstart-model-classification.js
@@ -153,4 +153,40 @@ assert.deepStrictEqual(
 );
 assert.strictEqual(quickstartService.normalizeBaseUrls('   '), null, 'Blank input should return null');
 
+// ── resolveOcrProviderDefault ────────────────────────────────────────────────
+// Regression coverage for issue #236: the OCR dropdown must never be gated on
+// the vision name-heuristic (a dedicated OCR model like Mistral's
+// `mistral-ocr-latest` matches no vision hint and would classify as
+// ['text'] below, exactly like a plain chat model). Only the OCR
+// *provider* default is host-based, and only for the one endpoint this
+// codebase already special-cases elsewhere (services/setupService.js
+// getMistralUrlValidationOptions).
+
+assert.deepStrictEqual(
+  quickstartService.classifyModelName('mistral-ocr-latest'),
+  ['text'],
+  'A dedicated OCR model with an unfamiliar name must not be silently excluded from the OCR dropdown just because it fails the vision heuristic'
+);
+
+assert.strictEqual(
+  quickstartService.resolveOcrProviderDefault('https://api.mistral.ai'),
+  'mistral',
+  'The detected Mistral API host should default the OCR provider to the dedicated Mistral OCR path'
+);
+assert.strictEqual(
+  quickstartService.resolveOcrProviderDefault('https://api.mistral.ai/v1'),
+  'mistral',
+  'A versioned Mistral URL should still resolve to the mistral OCR provider default'
+);
+assert.strictEqual(
+  quickstartService.resolveOcrProviderDefault('http://192.168.1.5:1234'),
+  'custom',
+  'A local/non-Mistral host should default to the custom (chat-completions) OCR provider'
+);
+assert.strictEqual(
+  quickstartService.resolveOcrProviderDefault(''),
+  'custom',
+  'A blank host should fall back to the custom OCR provider default'
+);
+
 console.log('✅ test-quickstart-model-classification passed');

--- a/tests/test-setup-wizard-quickstart.js
+++ b/tests/test-setup-wizard-quickstart.js
@@ -165,6 +165,32 @@ const detectionResponse = {
   message: 'Detected LM Studio: 3 models (2 text, 1 vision, 1 embedding).'
 };
 
+// Regression fixture for issue #236: a dedicated OCR model (like Mistral's
+// mistral-ocr-latest) matches no vision name-heuristic hint, so it only ever
+// shows up in textModels, never visionModels. The OCR dropdown must still
+// offer it, and a detected api.mistral.ai host must default the OCR
+// provider to 'mistral' instead of 'custom'.
+const mistralDetectionResponse = {
+  success: true,
+  detection: {
+    flavor: 'openai-compatible',
+    aiProvider: 'custom',
+    resolvedAiApiUrl: 'https://api.mistral.ai/v1',
+    ocrProvider: 'mistral',
+    resolvedOcrApiUrl: 'https://api.mistral.ai/v1',
+    models: [
+      { id: 'mistral-small-latest', capabilities: ['text'], state: null, source: 'heuristic' },
+      { id: 'mistral-ocr-latest', capabilities: ['text'], state: null, source: 'heuristic' }
+    ],
+    textModels: ['mistral-small-latest', 'mistral-ocr-latest'],
+    visionModels: [],
+    embeddingModels: [],
+    suggestedAiModel: 'mistral-small-latest',
+    suggestedOcrModel: null
+  },
+  message: 'Detected an OpenAI-compatible API: 2 models (2 text, 0 vision, 0 embedding).'
+};
+
 let lastFetchUrl = null;
 let lastFetchBody = null;
 const fetchedUrls = [];
@@ -327,6 +353,26 @@ wizard.quickstartApiKey.value = 'test-key';
   await wizard.runQuickstartSaveFlow();
   assert.ok(fetchedUrls.includes('/api/setup/ai/test'), 'Failing save flow should still run the AI test');
   assert.ok(!fetchedUrls.includes('/api/setup/complete'), 'Failing AI test must not finalize setup');
+
+  // Regression for #236: a dedicated OCR model with no vision-heuristic
+  // match must still be selectable, and a detected Mistral host must
+  // default the OCR provider to 'mistral' instead of always 'custom'.
+  responsesByUrl['/api/setup/quickstart/detect'] = mistralDetectionResponse;
+  wizard.quickstartBaseUrl.value = 'https://api.mistral.ai/v1';
+  wizard.quickstartApiKey.value = 'mistral-key';
+  await wizard.runQuickstartDetect();
+
+  assert.strictEqual(wizard.quickstartOcrModel.disabled, false, 'OCR model dropdown must stay enabled even when no model matches the vision name-heuristic, as long as candidate models exist');
+  assert.strictEqual(wizard.quickstartEnableOcr.disabled, false, 'Enable-OCR checkbox must stay enabled when any candidate model exists');
+  assert.strictEqual(wizard.quickstartEnableOcr.checked, true, 'Enable-OCR checkbox should default to checked when candidate models exist');
+
+  // No vision-heuristic match means no suggestedOcrModel; the user picks
+  // the dedicated OCR model manually.
+  wizard.quickstartOcrModel.value = 'mistral-ocr-latest';
+  wizard.applyQuickstartToManualFields();
+
+  assert.strictEqual(wizard.mistralOcrModel.value, 'mistral-ocr-latest', 'Manually selecting the dedicated OCR model should flow through to the manual OCR model field');
+  assert.strictEqual(wizard.ocrProvider.value, 'mistral', 'A detected api.mistral.ai host should default the OCR provider to mistral');
 
   console.log('✅ test-setup-wizard-quickstart passed');
 })().catch((error) => {

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -265,7 +265,7 @@
                             </select>
                         </div>
                         <div class="space-y-2">
-                            <label for="quickstartOcrModel" class="text-sm font-medium">Suggested OCR model (vision-capable)</label>
+                            <label for="quickstartOcrModel" class="text-sm font-medium">OCR model</label>
                             <select id="quickstartOcrModel" class="setup-input" disabled>
                                 <option value="">Run detection first</option>
                             </select>


### PR DESCRIPTION
## Summary
- Quickstart auto-detect classifies models by name heuristics only (`classifyModelName()`), and the "Suggested OCR model" dropdown/checkbox in Step 5 was gated entirely on the resulting `visionModels` list. A dedicated OCR model with an unfamiliar name — e.g. Mistral's `mistral-ocr-latest` — matches none of the hardcoded vision hints, so it classifies as `['text']` and never appeared in that list. The dropdown showed "No vision-capable models found" and the "enable OCR" checkbox was disabled, even though the model exists and works.
- `detectAndClassify()` also always returned `ocrProvider: 'custom'`, never the `'mistral'` OCR provider that manual setup already fully supports.
- **Considered and rejected:** parsing the `capabilities` object some OpenAI-compatible `/v1/models` responses include (Mistral does this; LM Studio/Ollama/plain OpenAI-compatible servers don't). That's an undocumented, vendor-specific extension, not part of the OpenAI spec, and would only special-case one provider while leaving every other naming scheme on the same guesswork.
- **Fix:** stop trying to *classify* which models are OCR-capable at all (name heuristic or vendor metadata can both miss real models) and instead offer the same non-embedding candidate list already used for the AI dropdown (`textModels` — every model is already exactly one of `['embedding']` / `['text']` / `['text','vision']`, so "has text capability" already means "not embedding-only"). A heuristic `suggestedOcrModel` still pre-selects a sensible default when one exists; otherwise the user picks manually instead of hitting a dead-end dropdown.
- Added `resolveOcrProviderDefault()` — a plain host-string check (mirrors the existing `api.mistral.ai` check in `setupService.getMistralUrlValidationOptions`) — so the OCR provider defaults to `'mistral'` only when the detected host is actually Mistral's API, `'custom'` otherwise. A wrong default is never a dead end: the "OCR fallback" step is its own always-visible wizard step (not nested under the AI step's Quickstart/Manual toggle), so the user can change the provider dropdown themselves regardless.
- Updated the dropdown label in `views/setup.ejs` from "Suggested OCR model (vision-capable)" to "OCR model" since it's no longer heuristic-filtered.
- Also fixed the same three pre-existing ESLint issues in `setup.js` as #238 (missing `/* global Swal */`, unused `catch (_error)`, stale `no-await-in-loop` disable comment).

## Test plan
- [x] `tests/test-quickstart-model-classification.js`: added `classifyModelName('mistral-ocr-latest') === ['text']` (documents why the dropdown must not gate on the vision heuristic) and `resolveOcrProviderDefault()` cases (Mistral host, versioned Mistral URL, local/non-Mistral host, blank host).
- [x] `tests/test-setup-wizard-quickstart.js`: added a second detection fixture (openai-compatible, `api.mistral.ai`, a model present only in `textModels`) asserting the OCR dropdown/checkbox stay enabled, manual selection flows through to the manual OCR model field, and the OCR provider defaults to `mistral`. Verified this assertion actually fails without the fix (reverted the source changes locally, confirmed red, restored).
- [x] `node scripts/run-tests.js --all`: 42 passed, 7 skipped (server-dependent), 0 failed.
- [x] `npx eslint` clean on all changed JS files.
- [x] `node scripts/regen-openapi.js` produces no diff (no new response field, just a different `ocrProvider` value).
- [ ] As in #238/#239, `npx prettier --check` still fails on `setup.js`/`quickstartService.js`/the two test files — pre-existing formatting drift confirmed present on `origin/main` before this change, intentionally left untouched per the same discussion with the repo maintainer.

Closes #236


---
_Generated by [Claude Code](https://claude.ai/code/session_0157iEcJwymtoB8fgX429hBj)_