### PR TITLE
fix(setup): strip API_KEY and JWT_SECRET from setup bootstrap payload

### DIFF
--- a/routes/setup.js
+++ b/routes/setup.js
@@ -31,6 +31,9 @@ const {
   THUMBNAIL_CACHE_DIR,
   getThumbnailCachePath,
 } = require('../services/thumbnailCachePaths');
+const {
+  sanitizeConfigForBootstrap,
+} = require('../services/bootstrapConfigSanitizer');
 const config = require('../config/config.js');
 require('dotenv').config({ path: '../data/.env' });
 
@@ -4226,24 +4229,6 @@ async function detectQuickstartForSetup({
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-// Helper: Sanitize config for bootstrap (remove secrets)
-function sanitizeConfigForBootstrap(config) {
-  const sanitized = { ...config };
-  const secretFields = [
-    'PAPERLESS_API_TOKEN',
-    'OPENAI_API_KEY',
-    'OLLAMA_API_KEY',
-    'CUSTOM_API_KEY',
-    'AZURE_API_KEY',
-    'OCR_API_KEY',
-    'MISTRAL_API_KEY',
-  ];
-  secretFields.forEach((field) => {
-    delete sanitized[field];
-  });
-  return sanitized;
-}
-
 router.get('/setup', async (req, res) => {
   try {
     // SECURITY: Check setup state first to detect degraded conditions

--- a/services/bootstrapConfigSanitizer.js
+++ b/services/bootstrapConfigSanitizer.js
@@ -1,0 +1,29 @@
+// Sanitises configuration before it is serialised into the setup bootstrap
+// payload (window.__SETUP_BOOTSTRAP__) delivered to the browser. Any secret
+// listed here must never reach client-side HTML, even in partial/degraded
+// setup states. Related advisory: GHSA-84cq-vv67-g8xx.
+const BOOTSTRAP_SECRET_FIELDS = [
+  'PAPERLESS_API_TOKEN',
+  'OPENAI_API_KEY',
+  'OLLAMA_API_KEY',
+  'CUSTOM_API_KEY',
+  'AZURE_API_KEY',
+  'OCR_API_KEY',
+  'MISTRAL_API_KEY',
+  'API_KEY',
+  'JWT_SECRET',
+];
+
+// Returns a shallow copy of config with every secret field removed.
+function sanitizeConfigForBootstrap(config) {
+  const sanitized = { ...config };
+  for (const field of BOOTSTRAP_SECRET_FIELDS) {
+    delete sanitized[field];
+  }
+  return sanitized;
+}
+
+module.exports = {
+  BOOTSTRAP_SECRET_FIELDS,
+  sanitizeConfigForBootstrap,
+};

--- a/tests/test-setup-bootstrap-security.js
+++ b/tests/test-setup-bootstrap-security.js
@@ -1,16 +1,14 @@
 // tests/test-setup-bootstrap-security.js
-const express = require('express');
 const fs = require('fs').promises;
 const path = require('path');
-const sqlite3 = require('better-sqlite3');
 
 // Test: Verify secrets are NOT exposed in setup bootstrap
 async function testSetupBootstrapNoSecrets() {
   console.log('\n=== Test 1: Setup Bootstrap Secret Exposure ===');
-  
+
   try {
     const setupService = require('../services/setupService.js');
-    
+
     // Verify isDatabaseHealthy() method exists
     if (typeof setupService.isDatabaseHealthy !== 'function') {
       throw new Error('isDatabaseHealthy() method not found in setupService');
@@ -23,50 +21,54 @@ async function testSetupBootstrapNoSecrets() {
     }
     console.log('✓ getSetupState() method exists');
 
-    // Test sanitizeConfigForBootstrap function
+    // Exercise the REAL sanitizer used by the setup bootstrap, not a copy,
+    // so this test fails if the production strip list regresses.
+    const {
+      sanitizeConfigForBootstrap,
+      BOOTSTRAP_SECRET_FIELDS,
+    } = require('../services/bootstrapConfigSanitizer.js');
+
     const testConfig = {
       PAPERLESS_API_TOKEN: 'secret-token-123',
       OPENAI_API_KEY: 'sk-secret-key',
+      OLLAMA_API_KEY: 'ollama-secret',
       AZURE_API_KEY: 'azure-secret',
       MISTRAL_API_KEY: 'mistral-secret',
       CUSTOM_API_KEY: 'custom-secret',
+      OCR_API_KEY: 'ocr-secret',
       API_KEY: 'paperless-app-api-key',
+      JWT_SECRET: 'jwt-signing-secret',
       PAPERLESS_API_URL: 'http://localhost:8000',
       AI_PROVIDER: 'openai',
-      OPENAI_MODEL: 'gpt-4o-mini'
-    };
-
-    // The sanitizeConfigForBootstrap function should be in routes/setup.js
-    // For now, we'll simulate it
-    const sanitizeConfigForBootstrap = (config) => {
-      const sanitized = { ...config };
-      const secretFields = [
-        'PAPERLESS_API_TOKEN',
-        'OPENAI_API_KEY',
-        'CUSTOM_API_KEY',
-        'AZURE_API_KEY',
-        'MISTRAL_API_KEY',
-        'API_KEY'
-      ];
-      secretFields.forEach(field => {
-        delete sanitized[field];
-      });
-      return sanitized;
+      OPENAI_MODEL: 'gpt-4o-mini',
     };
 
     const sanitizedConfig = sanitizeConfigForBootstrap(testConfig);
-    
-    // Verify secrets are removed
-    const secretFields = ['PAPERLESS_API_TOKEN', 'OPENAI_API_KEY', 'AZURE_API_KEY', 'MISTRAL_API_KEY', 'CUSTOM_API_KEY', 'API_KEY'];
-    for (const field of secretFields) {
+
+    // Verify every declared secret field is removed
+    for (const field of BOOTSTRAP_SECRET_FIELDS) {
       if (sanitizedConfig[field] !== undefined) {
-        throw new Error(`Secret field ${field} was not removed from bootstrap config`);
+        throw new Error(
+          `Secret field ${field} was not removed from bootstrap config`
+        );
+      }
+    }
+    // Regression guard for GHSA-84cq: API_KEY and JWT_SECRET were previously
+    // missing from the production strip list.
+    for (const field of ['API_KEY', 'JWT_SECRET']) {
+      if (sanitizedConfig[field] !== undefined) {
+        throw new Error(
+          `Secret field ${field} must be stripped from bootstrap config`
+        );
       }
     }
     console.log('✓ All secret fields removed from bootstrap config');
 
     // Verify non-secret fields are preserved
-    if (!sanitizedConfig.PAPERLESS_API_URL || sanitizedConfig.PAPERLESS_API_URL !== 'http://localhost:8000') {
+    if (
+      !sanitizedConfig.PAPERLESS_API_URL ||
+      sanitizedConfig.PAPERLESS_API_URL !== 'http://localhost:8000'
+    ) {
       throw new Error('Non-secret fields should be preserved');
     }
     console.log('✓ Non-secret fields preserved');
@@ -82,23 +84,26 @@ async function testSetupBootstrapNoSecrets() {
 // Test: Verify database health check detects corrupted state
 async function testDatabaseHealthCheck() {
   console.log('\n=== Test 2: Database Health Check ===');
-  
+
   try {
     const setupService = require('../services/setupService.js');
-    const documentModel = require('../models/document.js');
 
     // Test 1: Healthy database should return true
     const healthStatus = await setupService.isDatabaseHealthy();
     if (typeof healthStatus !== 'boolean') {
       throw new Error('isDatabaseHealthy() should return a boolean value');
     }
-    console.log(`✓ isDatabaseHealthy() returns boolean (current: ${healthStatus})`);
+    console.log(
+      `✓ isDatabaseHealthy() returns boolean (current: ${healthStatus})`
+    );
 
     // Test 2: Verify getSetupState returns valid states
     const validStates = ['first-run', 'partial', 'degraded', 'configured'];
     const setupState = await setupService.getSetupState();
     if (!validStates.includes(setupState)) {
-      throw new Error(`Invalid setup state: ${setupState}. Expected one of: ${validStates.join(', ')}`);
+      throw new Error(
+        `Invalid setup state: ${setupState}. Expected one of: ${validStates.join(', ')}`
+      );
     }
     console.log(`✓ getSetupState() returns valid state: ${setupState}`);
 
@@ -113,7 +118,7 @@ async function testDatabaseHealthCheck() {
 // Test: Verify degraded state detection logic
 async function testDegradedStateDetection() {
   console.log('\n=== Test 3: Degraded State Detection Logic ===');
-  
+
   try {
     const setupService = require('../services/setupService.js');
 
@@ -121,20 +126,26 @@ async function testDegradedStateDetection() {
     // - .env file exists
     // - Configuration is complete
     // - But database is unhealthy
-    
+
     // We can't easily simulate a corrupted DB in this test,
     // but we can verify the logic flow
     const state = await setupService.getSetupState();
-    
+
     if (state === 'degraded') {
       console.log('✓ System detected as being in degraded state');
       console.log('  → This means config exists but database is unhealthy');
-      console.log('  → /setup endpoint will return 500 error (no secrets exposed)')
+      console.log(
+        '  → /setup endpoint will return 500 error (no secrets exposed)'
+      );
     } else {
-      console.log(`ℹ Current system state: ${state} (not degraded in this environment)`);
+      console.log(
+        `ℹ Current system state: ${state} (not degraded in this environment)`
+      );
     }
 
-    console.log('\n✅ Test 3 PASSED: Degraded state detection logic verified\n');
+    console.log(
+      '\n✅ Test 3 PASSED: Degraded state detection logic verified\n'
+    );
     return true;
   } catch (error) {
     console.error('\n❌ Test 3 FAILED:', error.message, '\n');
@@ -145,7 +156,7 @@ async function testDegradedStateDetection() {
 // Test: Verify setup.ejs template structure
 async function testSetupTemplateStructure() {
   console.log('\n=== Test 4: Setup.ejs Template Structure ===');
-  
+
   try {
     const templatePath = path.join(process.cwd(), 'views', 'setup.ejs');
     const templateContent = await fs.readFile(templatePath, 'utf8');
@@ -173,31 +184,45 @@ async function testSetupTemplateStructure() {
 // Test: Verify setup-error.ejs template exists
 async function testSetupErrorTemplate() {
   console.log('\n=== Test 5: Setup Error Template ===');
-  
+
   try {
     const templatePath = path.join(process.cwd(), 'views', 'setup-error.ejs');
-    
+
     try {
       await fs.access(templatePath);
       console.log('✓ setup-error.ejs template exists');
     } catch (err) {
-      throw new Error(`setup-error.ejs template not found at ${templatePath}`);
+      throw new Error(`setup-error.ejs template not found at ${templatePath}`, {
+        cause: err,
+      });
     }
 
     const templateContent = await fs.readFile(templatePath, 'utf8');
 
     // Verify template doesn't contain any secret field references
-    const secretFields = ['PAPERLESS_API_TOKEN', 'OPENAI_API_KEY', 'AZURE_API_KEY', 'MISTRAL_API_KEY'];
+    const secretFields = [
+      'PAPERLESS_API_TOKEN',
+      'OPENAI_API_KEY',
+      'AZURE_API_KEY',
+      'MISTRAL_API_KEY',
+    ];
     for (const field of secretFields) {
       if (templateContent.includes(field)) {
-        throw new Error(`setup-error.ejs should not reference secret field: ${field}`);
+        throw new Error(
+          `setup-error.ejs should not reference secret field: ${field}`
+        );
       }
     }
     console.log('✓ setup-error.ejs contains no secret field references');
 
     // Verify error message templates are present
-    if (!templateContent.includes('errorMessage') || !templateContent.includes('supportText')) {
-      throw new Error('setup-error.ejs should have errorMessage and supportText placeholders');
+    if (
+      !templateContent.includes('errorMessage') ||
+      !templateContent.includes('supportText')
+    ) {
+      throw new Error(
+        'setup-error.ejs should have errorMessage and supportText placeholders'
+      );
     }
     console.log('✓ setup-error.ejs has error message placeholders');
 
@@ -217,18 +242,20 @@ async function runAllTests() {
   console.log('╚════════════════════════════════════════════════════════╝');
 
   const results = [];
-  
+
   results.push(await testSetupBootstrapNoSecrets());
   results.push(await testDatabaseHealthCheck());
   results.push(await testDegradedStateDetection());
   results.push(await testSetupTemplateStructure());
   results.push(await testSetupErrorTemplate());
 
-  const passed = results.filter(r => r).length;
+  const passed = results.filter((r) => r).length;
   const total = results.length;
 
   console.log('\n╔════════════════════════════════════════════════════════╗');
-  console.log(`║     Test Results: ${passed}/${total} Passed                          ║`);
+  console.log(
+    `║     Test Results: ${passed}/${total} Passed                          ║`
+  );
   console.log('╚════════════════════════════════════════════════════════╝\n');
 
   return passed === total;
@@ -237,10 +264,10 @@ async function runAllTests() {
 // Run tests if executed directly
 if (require.main === module) {
   runAllTests()
-    .then(success => {
+    .then((success) => {
       process.exit(success ? 0 : 1);
     })
-    .catch(error => {
+    .catch((error) => {
       console.error('Fatal test error:', error);
       process.exit(1);
     });


### PR DESCRIPTION
## Background

Security advisory **GHSA-84cq-vv67-g8xx** (secret disclosure via the setup bootstrap) is already closed for its core remote-unauthenticated vector — degraded-state `500`, provider tokens stripped, and the localhost / `ALLOW_REMOTE_SETUP` guard from GHSA-v4jq. A re-audit found a **residual gap**:

- The production `sanitizeConfigForBootstrap()` in `routes/setup.js` stripped the seven provider tokens but **not `API_KEY` or `JWT_SECRET`**.
- Both are persisted to runtime config (built into `finalConfig` on setup completion) and can be merged into the bootstrap config in the `env-configured-but-no-users` state.
- The regression test only exercised a **local copy** of the sanitiser (which happened to include `API_KEY`), so it passed while the real function silently omitted `API_KEY` and `JWT_SECRET`.

## Changes

- **New** `services/bootstrapConfigSanitizer.js` — single source of truth exporting `sanitizeConfigForBootstrap()` and `BOOTSTRAP_SECRET_FIELDS`. Strip list now includes `API_KEY` and `JWT_SECRET` in addition to the provider tokens.
- `routes/setup.js` — remove the local, incomplete sanitiser; import the shared module (call site unchanged).
- `tests/test-setup-bootstrap-security.js` — exercise the **real** exported sanitiser instead of a simulated copy, with an explicit regression guard asserting `API_KEY`/`JWT_SECRET` are stripped. Also removes unused requires and attaches the caught error as `cause` so the touched file passes ESLint (Prettier reformatted the file).

## Testing

- `node scripts/run-tests.js --test setup-bootstrap-security` → **PASS**
- `node scripts/run-tests.js --all` → **45 passed, 6 skipped** (server-dependent), **0 failed**
- ESLint + Prettier `--check` on changed files → clean
- OpenAPI drift check → in sync (no API surface change)

## Impact

Secrets can no longer be serialised into the client-delivered setup bootstrap, closing the residual `API_KEY` / `JWT_SECRET` gap. No behaviour change for the normal setup flow; non-secret config is still passed through. The test now fails if the production strip list regresses.

## Upstream Status

Not submitted upstream (`clusterzx/paperless-ai`); specific to the **next** fork's GHSA-84cq remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SohUC9cKWyz2Ydx449MBC
