### PR TITLE
chore(release): add v2026.08.01 changelog entries and bump version

### DIFF
--- a/config/changelog.js
+++ b/config/changelog.js
@@ -54,10 +54,19 @@ const RELEASES = [
   {
     version: 'v2026.07.04',
     entries: [
-      'Fix: Quickstart OCR detection now suggests and lists dedicated OCR models (e.g. Mistral\'s mistral-ocr-latest) instead of requiring vision-capable naming, in both the Setup Wizard and Settings page',
+      "Fix: Quickstart OCR detection now suggests and lists dedicated OCR models (e.g. Mistral's mistral-ocr-latest) instead of requiring vision-capable naming, in both the Setup Wizard and Settings page",
       'Fix: Setup wizard no longer leaves a stale AI provider selected when switching from Quickstart to manual AI configuration',
       'Fix: AI response/prompt log files resolve relative to the working directory on native (non-Docker) installs',
       'Improvement: Quickstart\'s "use this service for OCR" option is now a proper ON/OFF switch, matching the rest of the settings UI',
+    ],
+  },
+  {
+    version: 'v2026.08.01',
+    entries: [
+      'Fix: Document scanning no longer stops permanently when Paperless-ngx is unreachable at startup - the schedule is armed regardless, retries during startup, and recovers on its own without a restart',
+      'Fix: RECONCILIATION_ENABLED=no now actually disables automatic reconciliation',
+      'Improvement: The /health endpoint reports scanner state and answers 503 while document scanning is degraded, so monitoring can detect a stalled scan loop <a href="https://zettelrob.be/getting-started/monitoring/" target="_blank" rel="noopener">(see here)</a>',
+      'Improvement: The dashboard shows a warning banner while document scanning is not working',
     ],
   },
 ];

--- a/config/config.js
+++ b/config/config.js
@@ -352,7 +352,7 @@ startupLog(logLevel, 'info', 'Configuration loaded:', {
 });
 
 module.exports = {
-  PAPERLESS_AI_VERSION: 'v2026.07.04',
+  PAPERLESS_AI_VERSION: 'v2026.08.01',
   CONFIGURED: false,
   configSourceMode: CONFIG_SOURCE_MODE,
   getApiKey,


### PR DESCRIPTION
Follow-up to #274 (already merged).

`config/changelog.js` feeds the "What's New" modal shown to users after an update. The scanner work from #274 is user-visible — a permanently dead scan loop, a health endpoint that now answers 503, a new dashboard banner — so it belongs there, not just on the docs site.

## Changes

- **`config/changelog.js`**: new `v2026.08.01` block with four entries (startup scan fix, `RECONCILIATION_ENABLED=no` fix, `/health` scanner reporting, dashboard banner). The health entry links to the new [Monitoring page](https://zettelrob.be/getting-started/monitoring/), matching the existing pattern of the `v2026.05.01` block.
- **`config/config.js`**: `PAPERLESS_AI_VERSION` bumped to `v2026.08.01`. The header comment in `changelog.js` requires the newest block to stay in sync with it, and the modal would otherwise announce a version the UI does not show.
- `config/changelog.js` was not prettier-clean before this change (one pre-existing line, quote style only) — reformatted so the lint job passes.

## Testing

- `require('./config/changelog')` → `v2026.08.01`, four entries; verified identical to `PAPERLESS_AI_VERSION`
- `node scripts/run-tests.js --all` → 47 passed, 6 skipped, 0 failed
- eslint + prettier clean; `regen-openapi.js` produces no diff (the spec pins its own `info.version` at `1.0.0` and does not track the app version)

## Note for the release

After merging, the UI reports `v2026.08.01` everywhere and the What's New modal fires once per user — so tag the release accordingly. The docs site already carries the matching changelog entry and the Monitoring page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgY7WruM1oXDMJZqVDWR9K